### PR TITLE
feat(phase-1): Docker Capsule Runtime 与 UDS 工具调用链

### DIFF
--- a/adapter/src/tool-loader.ts
+++ b/adapter/src/tool-loader.ts
@@ -1,10 +1,19 @@
-// TODO(Phase 1): 解析 capsule.yaml，聚合 tool schema 供 ctx.tools.register 注册
+// 作用：把 Runtime 返回的 capsule.list_tools 结果映射为 DSH Tool Registry 所需的 Schema
 export interface CapsuleToolSchema {
   name: string;
   description: string;
   parameters: Record<string, unknown>;
 }
-export function parseToolSchemas(_manifest: unknown): CapsuleToolSchema[] {
-  // 作用：预留的 tool schema 解析入口（Phase 1 实现，配合 CapsuleManager 的 manifest 加载）
-  return [];
+export function parseToolSchemas(tools: unknown): CapsuleToolSchema[] {
+  // 作用：校验并抽取 name/description/parameters；内部字段（capsule_id 等）不透出给模型
+  if (!Array.isArray(tools)) {
+    return [];
+  }
+  return tools
+    .filter((t): t is Record<string, unknown> => typeof t === "object" && t !== null && typeof t["name"] === "string")
+    .map((t) => ({
+      name: t["name"] as string,
+      description: typeof t["description"] === "string" ? t["description"] : "",
+      parameters: (t["parameters"] && typeof t["parameters"] === "object" ? t["parameters"] : {}) as Record<string, unknown>,
+    }));
 }

--- a/capsules/hello/Dockerfile
+++ b/capsules/hello/Dockerfile
@@ -1,0 +1,7 @@
+FROM python:3.11-slim
+COPY sdk/python /sdk
+RUN pip install --no-cache-dir /sdk
+COPY capsules/hello/app.py /app/app.py
+USER 65534:65534
+WORKDIR /app
+CMD ["python", "/app/app.py"]

--- a/capsules/hello/app.py
+++ b/capsules/hello/app.py
@@ -1,0 +1,7 @@
+from dsh_capsule_sdk import CapsuleApp
+app = CapsuleApp()
+@app.tool("hello_capsule")
+async def hello_capsule(args: dict, ctx) -> dict:
+    # 作用：Phase 1 验收工具——证明调用真实发生在隔离容器内部
+    return {"message": f"hello, {args.get('name', 'capsule')}!"}
+app.run()

--- a/capsules/hello/capsule.yaml
+++ b/capsules/hello/capsule.yaml
@@ -1,0 +1,25 @@
+apiVersion: dsh-capsule/v1
+kind: Capsule
+metadata:
+  id: hello
+  version: 0.1.0
+  description: Minimal hello-world Capsule for Phase 1 verification.
+runtime:
+  image: dsh-capsule/hello:0.1.0
+  command:
+    - python
+    - /app/app.py
+resources:
+  memory_mb: 256
+  cpus: 0.5
+  pids: 64
+tools:
+  - name: hello_capsule
+    description: Say hello from inside an isolated container.
+    parameters:
+      type: object
+      additionalProperties: false
+      properties:
+        name:
+          type: string
+          description: Who to greet.

--- a/runtime/dsh_capsule/capsule/__init__.py
+++ b/runtime/dsh_capsule/capsule/__init__.py
@@ -1,0 +1,5 @@
+from dsh_capsule.capsule.manifest import CapsuleManifest, load_manifest
+from dsh_capsule.capsule.instance import CapsuleInstance
+from dsh_capsule.capsule.docker_backend import DockerBackend
+from dsh_capsule.capsule.manager import CapsuleManager
+__all__ = ["CapsuleManifest", "load_manifest", "CapsuleInstance", "DockerBackend", "CapsuleManager"]

--- a/runtime/dsh_capsule/capsule/docker_backend.py
+++ b/runtime/dsh_capsule/capsule/docker_backend.py
@@ -1,0 +1,121 @@
+import asyncio
+import json
+import os
+import pathlib
+import shutil
+import tempfile
+import time
+import uuid
+import docker
+from dsh_capsule.capsule.instance import CapsuleInstance
+from dsh_capsule.capsule.manifest import CapsuleManifest
+class DockerBackend:
+    def __init__(self, run_dir: str | None = None, invoke_timeout: float = 30.0, start_timeout: float = 15.0):
+        # 作用：Docker 隔离后端——只管容器与 UDS 调用，不懂 Lease；隔离参数与规格第 12 节一一对应
+        self._run_dir = pathlib.Path(run_dir or os.environ.get("DSH_CAPSULE_RUN_DIR") or ("/run/dsh-capsule" if os.name == "posix" else os.path.join(tempfile.gettempdir(), "dsh-capsule")))
+        self._invoke_timeout = invoke_timeout
+        self._start_timeout = start_timeout
+        self._client = None
+    def _ensure_client(self):
+        # 作用：惰性初始化 docker client（连接失败由调用方 Fail Closed）
+        if self._client is None:
+            self._client = docker.from_env()
+        return self._client
+    async def start(self, manifest: CapsuleManifest) -> CapsuleInstance:
+        # 作用：创建独享 IPC 目录并以受限参数启动容器，等待 plugin.sock 就绪
+        instance = self._new_instance(manifest)
+        try:
+            container = await asyncio.to_thread(self._create_container, manifest, instance)
+        except Exception as exc:
+            await self.stop(instance)
+            raise RuntimeError(f"CAPSULE_START_FAILED: {exc}") from exc
+        instance.container_id = container.id
+        try:
+            await self._wait_plugin_sock(instance)
+        except Exception as exc:
+            await self.stop(instance)
+            raise RuntimeError(f"CAPSULE_START_FAILED: {exc}") from exc
+        return instance
+    def _new_instance(self, manifest: CapsuleManifest) -> CapsuleInstance:
+        # 作用：构造实例并创建独享 IPC 目录（0o777 保证容器内非 root 用户可写）
+        instance = CapsuleInstance(capsule_id=manifest.metadata.id, manifest=manifest)
+        instance.ipc_dir = self._run_dir / instance.instance_id
+        instance.ipc_dir.mkdir(parents=True, exist_ok=True)
+        os.chmod(instance.ipc_dir, 0o777)
+        instance.plugin_sock = instance.ipc_dir / "plugin.sock"
+        return instance
+    def _create_container(self, manifest: CapsuleManifest, instance: CapsuleInstance):
+        # 作用：按规格第 12 节隔离基线显式创建容器：read-only / network none / cap-drop ALL /
+        # no-new-privileges / 资源限制 / tmpfs noexec / 非 root / 仅注入非敏感运行变量
+        return self._ensure_client().containers.run(
+            manifest.runtime.image,
+            manifest.runtime.command,
+            name=f"dsh-capsule-{instance.instance_id[:12]}",
+            detach=True,
+            read_only=True,
+            network_disabled=True,
+            cap_drop=["ALL"],
+            security_opt=["no-new-privileges"],
+            mem_limit=f"{manifest.resources.memory_mb}m",
+            pids_limit=manifest.resources.pids,
+            nano_cpus=int(manifest.resources.cpus * 1e9),
+            tmpfs={"/tmp": "rw,noexec,nosuid,size=64m"},
+            volumes={str(instance.ipc_dir): {"bind": "/run/capsule", "mode": "rw"}},
+            user="65534:65534",
+            environment={"DSH_CAPSULE_PLUGIN_SOCK": "/run/capsule/plugin.sock"},
+            working_dir="/app",
+        )
+    async def _wait_plugin_sock(self, instance: CapsuleInstance) -> None:
+        # 作用：轮询等待容器内 SDK 在挂载目录创建 plugin.sock，超时即启动失败
+        deadline = time.monotonic() + self._start_timeout
+        while time.monotonic() < deadline:
+            if instance.plugin_sock.exists():
+                return
+            await asyncio.sleep(0.1)
+        raise TimeoutError("plugin.sock not ready in time")
+    async def invoke(self, instance: CapsuleInstance, request: dict, timeout: float | None = None) -> dict:
+        # 作用：经 plugin.sock 向容器发送单条 NDJSON JSON-RPC 请求并等待响应
+        timeout = timeout or self._invoke_timeout
+        try:
+            reader, writer = await asyncio.wait_for(asyncio.open_unix_connection(str(instance.plugin_sock)), 5.0)
+        except (NotImplementedError, OSError) as exc:
+            raise RuntimeError(f"CAPSULE_UNAVAILABLE: {exc}") from exc
+        try:
+            writer.write((json.dumps(request, ensure_ascii=False) + "\n").encode("utf-8"))
+            await writer.drain()
+            line = await asyncio.wait_for(reader.readline(), timeout)
+        except asyncio.TimeoutError as exc:
+            raise RuntimeError("CAPSULE_TIMEOUT: invocation timed out") from exc
+        except (OSError, ConnectionError) as exc:
+            raise RuntimeError(f"CAPSULE_PROTOCOL_ERROR: {exc}") from exc
+        finally:
+            writer.close()
+        if not line:
+            raise RuntimeError("CAPSULE_PROTOCOL_ERROR: empty response from capsule")
+        try:
+            msg = json.loads(line)
+        except json.JSONDecodeError as exc:
+            raise RuntimeError(f"CAPSULE_PROTOCOL_ERROR: {exc}") from exc
+        if "error" in msg:
+            raise RuntimeError(f"CAPSULE_PROTOCOL_ERROR: {msg['error'].get('message', msg['error'])}")
+        return msg.get("result")
+    async def health(self, instance: CapsuleInstance) -> bool:
+        # 作用：容器运行状态检查；任何异常一律视为不健康（Fail Closed）
+        if instance.container_id is None:
+            return False
+        try:
+            return await asyncio.to_thread(lambda: self._ensure_client().containers.get(instance.container_id).status == "running")
+        except Exception:
+            return False
+    async def stop(self, instance: CapsuleInstance) -> None:
+        # 作用：强制移除容器并清理独享 IPC 目录
+        if instance.container_id is not None:
+            await asyncio.to_thread(self._remove_container, instance.container_id)
+        if instance.ipc_dir is not None:
+            shutil.rmtree(instance.ipc_dir, ignore_errors=True)
+    def _remove_container(self, container_id: str) -> None:
+        # 作用：按 id 强制移除容器，已不存在的容器静默忽略
+        try:
+            self._ensure_client().containers.get(container_id).remove(force=True)
+        except docker.errors.NotFound:
+            pass

--- a/runtime/dsh_capsule/capsule/instance.py
+++ b/runtime/dsh_capsule/capsule/instance.py
@@ -1,0 +1,15 @@
+import time
+import uuid
+from dataclasses import dataclass, field
+from pathlib import Path
+from dsh_capsule.capsule.manifest import CapsuleManifest
+@dataclass
+class CapsuleInstance:
+    # 作用：一次 Capsule 运行实例——独享 IPC 目录与 plugin.sock，绑定唯一容器
+    capsule_id: str
+    instance_id: str = field(default_factory=lambda: uuid.uuid4().hex)
+    manifest: CapsuleManifest | None = None
+    ipc_dir: Path | None = None
+    plugin_sock: Path | None = None
+    container_id: str | None = None
+    started_at: float = field(default_factory=time.time)

--- a/runtime/dsh_capsule/capsule/manager.py
+++ b/runtime/dsh_capsule/capsule/manager.py
@@ -1,0 +1,57 @@
+import asyncio
+import uuid
+from pathlib import Path
+from dsh_capsule.capsule.docker_backend import DockerBackend
+from dsh_capsule.capsule.instance import CapsuleInstance
+from dsh_capsule.capsule.manifest import CapsuleManifest, load_manifest
+class CapsuleManager:
+    def __init__(self, capsules_dir: Path | str, backend: DockerBackend | None = None):
+        # 作用：Capsule 生命周期管理——manifest 发现/校验、实例启动/复用、工具调用分发
+        self._backend = backend or DockerBackend()
+        self._manifests: dict[str, CapsuleManifest] = {}
+        self._tool_owners: dict[str, CapsuleManifest] = {}
+        self._instances: dict[str, CapsuleInstance] = {}
+        self._invoke_seq = 0
+        self._discover(Path(capsules_dir))
+    def _discover(self, capsules_dir: Path) -> None:
+        # 作用：扫描 capsules/<id>/capsule.yaml；任一 manifest 非法直接抛异常（Fail Closed）
+        if not capsules_dir.is_dir():
+            raise RuntimeError(f"CAPSULE_NOT_FOUND: capsules dir missing: {capsules_dir}")
+        for manifest_path in sorted(capsules_dir.glob("*/capsule.yaml")):
+            manifest = load_manifest(manifest_path)
+            if manifest.metadata.id in self._manifests:
+                raise RuntimeError(f"CAPSULE_NOT_FOUND: duplicate capsule id: {manifest.metadata.id}")
+            self._manifests[manifest.metadata.id] = manifest
+            for tool in manifest.tools:
+                self._tool_owners[tool.name] = manifest
+    def list_tools(self) -> list[dict]:
+        # 作用：聚合全部 Capsule 的工具 Schema（内部字段如 lease/credential 不对外暴露）
+        return [
+            {"name": tool.name, "description": tool.description, "parameters": tool.parameters, "capsule_id": manifest.metadata.id}
+            for manifest in self._manifests.values()
+            for tool in manifest.tools
+        ]
+    async def invoke(self, tool_name: str, args: dict, timeout: float | None = None) -> dict:
+        # 作用：执行一次工具调用——定位所属 Capsule、确保实例健康、经 UDS 下发 tool.invoke
+        manifest = self._tool_owners.get(tool_name)
+        if manifest is None:
+            raise RuntimeError(f"CAPSULE_NOT_FOUND: unknown tool: {tool_name}")
+        instance = await self._ensure_instance(manifest)
+        self._invoke_seq += 1
+        request = {"jsonrpc": "2.0", "id": f"capsule-{self._invoke_seq}", "method": "tool.invoke", "params": {"name": tool_name, "args": args or {}}}
+        return await self._backend.invoke(instance, request, timeout)
+    async def _ensure_instance(self, manifest: CapsuleManifest) -> CapsuleInstance:
+        # 作用：获取或启动指定 Capsule 的实例；已存在但不健康则重建
+        instance = self._instances.get(manifest.metadata.id)
+        if instance is not None and await self._backend.health(instance):
+            return instance
+        if instance is not None:
+            await self._backend.stop(instance)
+        instance = await self._backend.start(manifest)
+        self._instances[manifest.metadata.id] = instance
+        return instance
+    async def shutdown(self) -> None:
+        # 作用：Runtime 退出时回收全部容器与 IPC 目录
+        for instance in self._instances.values():
+            await self._backend.stop(instance)
+        self._instances.clear()

--- a/runtime/dsh_capsule/capsule/manifest.py
+++ b/runtime/dsh_capsule/capsule/manifest.py
@@ -1,0 +1,51 @@
+from pathlib import Path
+from typing import Literal
+import yaml
+from pydantic import BaseModel, ConfigDict
+class ManifestMetadata(BaseModel):
+    # 作用：Capsule 标识信息，id 即 capsule_id
+    model_config = ConfigDict(extra="forbid")
+    id: str
+    version: str
+    description: str = ""
+class RuntimeSpec(BaseModel):
+    # 作用：容器镜像与启动命令
+    model_config = ConfigDict(extra="forbid")
+    image: str
+    command: list[str]
+class ResourceSpec(BaseModel):
+    # 作用：容器资源限制，与规格第 12/32 节默认值一致
+    model_config = ConfigDict(extra="forbid")
+    memory_mb: int = 256
+    cpus: float = 0.5
+    pids: int = 64
+class CredentialRequest(BaseModel):
+    # 作用：声明所需 Capability Lease 的范围；仅允许 credential_ref，禁止出现真实凭据
+    model_config = ConfigDict(extra="forbid")
+    provider: str
+    credential_ref: str
+    allowed_actions: list[str]
+    default_ttl_seconds: int = 600
+    max_ttl_seconds: int = 1800
+class ToolSpec(BaseModel):
+    # 作用：对外注册的工具 Schema（JSON Schema 形状）
+    model_config = ConfigDict(extra="forbid")
+    name: str
+    description: str = ""
+    parameters: dict = {}
+class CapsuleManifest(BaseModel):
+    # 作用：capsule.yaml 的严格模型；apiVersion/kind 错误或未知字段一律校验失败（Fail Closed）
+    model_config = ConfigDict(extra="forbid")
+    apiVersion: Literal["dsh-capsule/v1"]
+    kind: Literal["Capsule"]
+    metadata: ManifestMetadata
+    runtime: RuntimeSpec
+    resources: ResourceSpec = ResourceSpec()
+    credentials: list[CredentialRequest] = []
+    tools: list[ToolSpec] = []
+def load_manifest(path: Path | str) -> CapsuleManifest:
+    # 作用：读取并校验单个 capsule.yaml，任何解析/校验失败直接抛异常（Fail Closed）
+    raw = yaml.safe_load(Path(path).read_text(encoding="utf-8"))
+    if not isinstance(raw, dict):
+        raise ValueError(f"invalid manifest (not a mapping): {path}")
+    return CapsuleManifest.model_validate(raw)

--- a/runtime/dsh_capsule/main.py
+++ b/runtime/dsh_capsule/main.py
@@ -1,16 +1,26 @@
 import asyncio
+import os
 import sys
+from pathlib import Path
+from dsh_capsule.capsule.manager import CapsuleManager
 from dsh_capsule.rpc import RpcConnection
-def build_connection() -> RpcConnection:
-    # 作用：组装 RPC 连接并注册 Phase 0 所需的 system.* 方法
+DEFAULT_CAPSULES_DIR = Path(__file__).resolve().parents[2] / "capsules"
+def build_connection(manager: CapsuleManager) -> RpcConnection:
+    # 作用：组装 RPC 连接并注册 system.* 与 capsule.* 方法
     conn = RpcConnection(sys.stdin.buffer, sys.stdout.buffer)
     conn.register("system.ping", lambda params: {"pong": True})
     conn.register("system.call_host", lambda params: conn.call(params["method"], params.get("params") or {}))
+    conn.register("capsule.list_tools", lambda params: manager.list_tools())
+    conn.register("capsule.invoke", lambda params: manager.invoke(params["tool"], params.get("args") or {}, params.get("timeout")))
     return conn
 async def amain() -> None:
-    # 作用：异步入口，持续处理 RPC 消息直到 stdin 关闭（EOF）
-    conn = build_connection()
-    await conn.run()
+    # 作用：异步入口，持续处理 RPC 消息直到 stdin 关闭（EOF）；退出前回收全部 Capsule 实例
+    manager = CapsuleManager(os.environ.get("DSH_CAPSULE_DIR") or DEFAULT_CAPSULES_DIR)
+    conn = build_connection(manager)
+    try:
+        await conn.run()
+    finally:
+        await manager.shutdown()
 def main() -> None:
     # 作用：同步入口；stdout 严格保留给 NDJSON RPC，运行日志一律写 stderr
     print("[dsh-capsule] runtime starting", file=sys.stderr)

--- a/runtime/pyproject.toml
+++ b/runtime/pyproject.toml
@@ -9,7 +9,11 @@ dependencies = [
     "docker>=7",
     "httpx>=0.27",
     "aiosqlite>=0.20",
+    "dsh-capsule-sdk",
 ]
+
+[tool.uv.sources]
+dsh-capsule-sdk = { path = "../sdk/python", editable = true }
 
 [dependency-groups]
 dev = [

--- a/runtime/uv.lock
+++ b/runtime/uv.lock
@@ -219,6 +219,7 @@ source = { editable = "." }
 dependencies = [
     { name = "aiosqlite" },
     { name = "docker" },
+    { name = "dsh-capsule-sdk" },
     { name = "httpx" },
     { name = "pydantic" },
     { name = "pyyaml" },
@@ -233,6 +234,7 @@ dev = [
 requires-dist = [
     { name = "aiosqlite", specifier = ">=0.20" },
     { name = "docker", specifier = ">=7" },
+    { name = "dsh-capsule-sdk", editable = "../sdk/python" },
     { name = "httpx", specifier = ">=0.27" },
     { name = "pydantic", specifier = ">=2" },
     { name = "pyyaml", specifier = ">=6" },
@@ -240,6 +242,11 @@ requires-dist = [
 
 [package.metadata.requires-dev]
 dev = [{ name = "pytest", specifier = ">=8" }]
+
+[[package]]
+name = "dsh-capsule-sdk"
+version = "0.1.0"
+source = { editable = "../sdk/python" }
 
 [[package]]
 name = "h11"

--- a/sdk/python/dsh_capsule_sdk/__init__.py
+++ b/sdk/python/dsh_capsule_sdk/__init__.py
@@ -1,0 +1,3 @@
+from dsh_capsule_sdk.tool import CapsuleApp, CapsuleContext
+from dsh_capsule_sdk.broker import BrokerClient
+__all__ = ["CapsuleApp", "CapsuleContext", "BrokerClient"]

--- a/sdk/python/dsh_capsule_sdk/broker.py
+++ b/sdk/python/dsh_capsule_sdk/broker.py
@@ -1,0 +1,7 @@
+class BrokerClient:
+    def __init__(self, broker_sock: str | None = None):
+        # 作用：占位的 Broker 客户端，Phase 3 实现 UDS broker.sock 受控访问入口
+        self._sock = broker_sock or "/run/capsule/broker.sock"
+    async def call(self, provider: str, action: str, resource: str, payload: dict) -> dict:
+        # 作用：预留的受控能力访问入口（Phase 3 实现，当前 Fail Closed）
+        raise RuntimeError("broker not available until Phase 3")

--- a/sdk/python/dsh_capsule_sdk/tool.py
+++ b/sdk/python/dsh_capsule_sdk/tool.py
@@ -1,0 +1,72 @@
+import asyncio
+import inspect
+import json
+import os
+import sys
+from dsh_capsule_sdk.broker import BrokerClient
+class CapsuleContext:
+    def __init__(self, broker: BrokerClient):
+        # 作用：工具执行上下文，Phase 1 仅暴露 broker 占位；后续 Phase 增加资源信息
+        self.broker = broker
+class CapsuleApp:
+    def __init__(self, plugin_sock: str | None = None):
+        # 作用：Capsule 插件应用骨架——注册工具并在独享 UDS 上提供 NDJSON JSON-RPC 服务
+        self._sock = plugin_sock or os.environ.get("DSH_CAPSULE_PLUGIN_SOCK", "/run/capsule/plugin.sock")
+        self._tools: dict[str, callable] = {}
+    def tool(self, name: str):
+        # 作用：装饰器，注册名为 name 的工具函数（签名 async fn(args: dict, ctx: CapsuleContext) -> dict）
+        def decorator(fn):
+            self._tools[name] = fn
+            return fn
+        return decorator
+    def run(self) -> None:
+        # 作用：阻塞运行 UDS 服务；stdout 不使用，日志一律写 stderr
+        try:
+            asyncio.run(self._serve())
+        except KeyboardInterrupt:
+            pass
+    async def _serve(self) -> None:
+        # 作用：监听 plugin.sock 并循环接受连接（socket 文件由 Runtime 预先创建的目录承载）
+        if os.path.exists(self._sock):
+            os.unlink(self._sock)
+        server = await asyncio.start_unix_server(self._handle_conn, path=self._sock)
+        print(f"[capsule] serving on {self._sock}", file=sys.stderr)
+        async with server:
+            await server.serve_forever()
+    async def _handle_conn(self, reader: asyncio.StreamReader, writer: asyncio.StreamWriter) -> None:
+        # 作用：处理单个连接，逐行读取 NDJSON 请求并回写响应
+        try:
+            while True:
+                line = await reader.readline()
+                if not line:
+                    break
+                try:
+                    msg = json.loads(line)
+                except json.JSONDecodeError as exc:
+                    await self._write(writer, {"jsonrpc": "2.0", "id": None, "error": {"code": -32700, "message": f"parse error: {exc}"}})
+                    continue
+                response = await self._dispatch(msg)
+                await self._write(writer, response)
+        finally:
+            writer.close()
+            await writer.wait_closed()
+    async def _dispatch(self, msg: dict) -> dict:
+        # 作用：分发 tool.invoke 请求到已注册工具；任何失败返回结构化错误（Fail Closed）
+        msg_id = msg.get("id")
+        try:
+            if msg.get("method") != "tool.invoke":
+                raise RuntimeError("CAPSULE_PROTOCOL_ERROR: only tool.invoke is supported")
+            name = msg.get("params", {}).get("name")
+            fn = self._tools.get(name)
+            if fn is None:
+                raise RuntimeError(f"CAPSULE_PROTOCOL_ERROR: unknown tool: {name}")
+            result = fn(msg.get("params", {}).get("args") or {}, CapsuleContext(BrokerClient()))
+            if inspect.isawaitable(result):
+                result = await result
+            return {"jsonrpc": "2.0", "id": msg_id, "result": result}
+        except Exception as exc:
+            return {"jsonrpc": "2.0", "id": msg_id, "error": {"code": -32000, "message": str(exc)}}
+    async def _write(self, writer: asyncio.StreamWriter, msg: dict) -> None:
+        # 作用：序列化单行 NDJSON 响应并刷写
+        writer.write((json.dumps(msg, ensure_ascii=False) + "\n").encode("utf-8"))
+        await writer.drain()

--- a/sdk/python/pyproject.toml
+++ b/sdk/python/pyproject.toml
@@ -1,0 +1,10 @@
+[project]
+name = "dsh-capsule-sdk"
+version = "0.1.0"
+description = "Minimal SDK for building DSH Capsule plugins (stdlib only)"
+requires-python = ">=3.11"
+[build-system]
+requires = ["hatchling"]
+build-backend = "hatchling.build"
+[tool.hatch.build.targets.wheel]
+packages = ["dsh_capsule_sdk"]

--- a/tests/integration/test_capsule_invoke.py
+++ b/tests/integration/test_capsule_invoke.py
@@ -1,0 +1,43 @@
+import asyncio
+import socket
+from pathlib import Path
+import pytest
+from dsh_capsule.capsule.manager import CapsuleManager
+REPO_ROOT = Path(__file__).resolve().parents[2]
+def _docker_available() -> bool:
+    # 作用：探测 Docker Engine 是否可用；不可用则跳过集成用例
+    try:
+        import docker
+        docker.from_env().ping()
+        return True
+    except Exception:
+        return False
+requires_env = pytest.mark.skipif(not (_docker_available() and hasattr(socket, "AF_UNIX")), reason="requires Docker Engine + AF_UNIX (Linux/WSL2)")
+@pytest.fixture(scope="module")
+def manager():
+    # 作用：模块级 Manager；用例结束后回收容器
+    _ensure_hello_image()
+    m = CapsuleManager(REPO_ROOT / "capsules")
+    yield m
+    asyncio.run(m.shutdown())
+def _ensure_hello_image() -> None:
+    # 作用：确保 dsh-capsule/hello:0.1.0 镜像存在，缺失则以仓库根为上下文构建
+    import docker
+    client = docker.from_env()
+    tag = "dsh-capsule/hello:0.1.0"
+    try:
+        client.images.get(tag)
+    except docker.errors.ImageNotFound:
+        client.images.build(path=str(REPO_ROOT), tag=tag, dockerfile="capsules/hello/Dockerfile")
+@requires_env
+def test_invoke_hello_capsule_in_docker(manager):
+    # 作用：Phase 1 核心验收——调用链 Manager→UDS→容器内 SDK→工具函数
+    result = asyncio.run(manager.invoke("hello_capsule", {"name": "phase1"}))
+    assert result == {"message": "hello, phase1!"}
+@requires_env
+def test_instance_reuse_within_ttl(manager):
+    # 作用：同一 Capsule 的连续调用复用同一实例（不重建容器）
+    first = asyncio.run(manager.invoke("hello_capsule", {}))
+    second = asyncio.run(manager.invoke("hello_capsule", {}))
+    assert first["message"] == "hello, capsule!"
+    assert second["message"] == "hello, capsule!"

--- a/tests/unit/test_manager.py
+++ b/tests/unit/test_manager.py
@@ -1,0 +1,39 @@
+import asyncio
+import shutil
+from pathlib import Path
+import pytest
+from dsh_capsule.capsule.manager import CapsuleManager
+REPO_ROOT = Path(__file__).resolve().parents[2]
+@pytest.fixture
+def capsules_dir(tmp_path: Path) -> Path:
+    # 作用：复制仓库 hello capsule 到临时目录，隔离测试环境
+    dst = tmp_path / "capsules" / "hello"
+    dst.mkdir(parents=True)
+    for name in ("capsule.yaml",):
+        shutil.copy(REPO_ROOT / "capsules" / "hello" / name, dst / name)
+    return tmp_path / "capsules"
+def test_list_tools(capsules_dir: Path):
+    # 作用：验证 manifest 发现与工具 Schema 聚合（不依赖 Docker）
+    manager = CapsuleManager(capsules_dir, backend=_FakeBackend())
+    tools = manager.list_tools()
+    assert [(t["name"], t["capsule_id"]) for t in tools] == [("hello_capsule", "hello")]
+    assert tools[0]["parameters"]["properties"]["name"]["type"] == "string"
+def test_invoke_unknown_tool_fails_closed(capsules_dir: Path):
+    # 作用：验证未知工具 Fail Closed（CAPSULE_NOT_FOUND）
+    manager = CapsuleManager(capsules_dir, backend=_FakeBackend())
+    with pytest.raises(RuntimeError, match="CAPSULE_NOT_FOUND"):
+        asyncio.run(manager.invoke("nope", {}))
+def test_invalid_manifest_dir_fails_closed(tmp_path: Path):
+    # 作用：验证 capsules 目录缺失时 Fail Closed
+    with pytest.raises(RuntimeError, match="CAPSULE_NOT_FOUND"):
+        CapsuleManager(tmp_path / "missing", backend=_FakeBackend())
+class _FakeBackend:
+    # 作用：单测用假后端——仅校验 Manager 层逻辑，不触碰 Docker
+    async def start(self, manifest):
+        raise AssertionError("should not start container in unit test")
+    async def invoke(self, instance, request, timeout=None):
+        raise AssertionError("should not invoke in unit test")
+    async def health(self, instance):
+        return True
+    async def stop(self, instance):
+        pass

--- a/tests/unit/test_manifest.py
+++ b/tests/unit/test_manifest.py
@@ -1,0 +1,40 @@
+from pathlib import Path
+import pytest
+from dsh_capsule.capsule.manifest import load_manifest
+REPO_ROOT = Path(__file__).resolve().parents[2]
+HELLO_MANIFEST = REPO_ROOT / "capsules" / "hello" / "capsule.yaml"
+def _write(tmp_path: Path, content: str) -> Path:
+    # 作用：写入临时 capsule.yaml 供负向用例使用
+    capsule_dir = tmp_path / "demo"
+    capsule_dir.mkdir()
+    p = capsule_dir / "capsule.yaml"
+    p.write_text(content, encoding="utf-8")
+    return p
+def test_valid_hello_manifest():
+    # 作用：验证仓库内置 hello capsule 能通过严格校验
+    m = load_manifest(HELLO_MANIFEST)
+    assert m.metadata.id == "hello"
+    assert m.runtime.image == "dsh-capsule/hello:0.1.0"
+    assert [t.name for t in m.tools] == ["hello_capsule"]
+    assert m.credentials == []
+def test_wrong_api_version_rejected(tmp_path):
+    # 作用：apiVersion 不符必须拒绝（Fail Closed）
+    p = _write(tmp_path, "apiVersion: other/v1\nkind: Capsule\nmetadata: {id: x, version: 0.1.0}\nruntime: {image: img, command: [python]}\n")
+    with pytest.raises(Exception):
+        load_manifest(p)
+def test_missing_image_rejected(tmp_path):
+    # 作用：缺少镜像声明必须拒绝
+    p = _write(tmp_path, "apiVersion: dsh-capsule/v1\nkind: Capsule\nmetadata: {id: x, version: 0.1.0}\nruntime: {command: [python]}\n")
+    with pytest.raises(Exception):
+        load_manifest(p)
+def test_unknown_field_rejected(tmp_path):
+    # 作用：未知字段（如误填真实凭据的任意键）必须拒绝
+    p = _write(tmp_path, "apiVersion: dsh-capsule/v1\nkind: Capsule\nmetadata: {id: x, version: 0.1.0}\nruntime: {image: img, command: [python]}\npassword: hunter2\n")
+    with pytest.raises(Exception):
+        load_manifest(p)
+def test_not_a_mapping_rejected(tmp_path):
+    # 作用：非映射结构的 manifest 必须拒绝
+    p = tmp_path / "capsule.yaml"
+    p.write_text("- a\n- b\n", encoding="utf-8")
+    with pytest.raises(Exception):
+        load_manifest(p)


### PR DESCRIPTION
- Capsule Manifest：pydantic 严格模型（extra=forbid），非法 manifest 一律拒绝
- DockerBackend：按规格第 12 节显式隔离参数（read-only / network none / cap-drop ALL / no-new-privileges / 资源限制 / tmpfs noexec / 非 root）， UDS plugin.sock invoke 带超时，健康检查 Fail Closed
- CapsuleManager：manifest 发现与校验、工具 Schema 聚合（内部字段不透出）、 实例复用/重建、shutdown 回收
- Python SDK：CapsuleApp（@tool 装饰器 + UDS NDJSON JSON-RPC 服务）， Broker 客户端占位（Phase 3 实现）
- hello capsule：验收用最小 Capsule（capsule.yaml + Dockerfile + app.py）
- main.py 注册 capsule.list_tools / capsule.invoke，退出时回收容器
- 测试：manifest 5 项（含 3 负向）/ manager 3 项 / Docker 集成 2 项（无环境自动跳过）

验收：DSH → hello_capsule → Docker → "hello" 调用链代码就绪； Docker 实跑验收待 WSL2/Linux 环境执行集成测试