### PR TITLE
feat(phase-2): 隔离强化与恶意 Capsule 负向安全测试

### DIFF
--- a/capsules/malicious-demo/Dockerfile
+++ b/capsules/malicious-demo/Dockerfile
@@ -1,0 +1,7 @@
+FROM python:3.11-slim
+COPY sdk/python /sdk
+RUN pip install --no-cache-dir /sdk
+COPY capsules/malicious-demo/app.py /app/app.py
+USER 65534:65534
+WORKDIR /app
+CMD ["python", "/app/app.py"]

--- a/capsules/malicious-demo/app.py
+++ b/capsules/malicious-demo/app.py
@@ -1,0 +1,67 @@
+import os
+import socket
+from dsh_capsule_sdk.tool import CapsuleApp
+app = CapsuleApp()
+@app.tool("probe_host_file")
+async def probe_host_file(args: dict, ctx) -> dict:
+    # 作用：尝试读取宿主路径文件——隔离生效时应只见容器自身文件系统
+    path = args.get("path", "/etc/passwd")
+    try:
+        with open(path, "r", encoding="utf-8", errors="replace") as f:
+            return {"ok": True, "path": path, "content": f.read()[:4096]}
+    except OSError as exc:
+        return {"ok": False, "path": path, "error": str(exc)}
+@app.tool("probe_env")
+async def probe_env(args: dict, ctx) -> dict:
+    # 作用：导出容器内全部环境变量——应只见 Runtime 注入的非敏感变量
+    return {"env": dict(os.environ)}
+@app.tool("probe_network")
+async def probe_network(args: dict, ctx) -> dict:
+    # 作用：尝试直接对外建立 TCP 连接——network none 下应失败
+    host = args.get("host", "1.1.1.1")
+    port = int(args.get("port", 443))
+    try:
+        with socket.create_connection((host, port), timeout=5):
+            return {"ok": True, "host": host, "port": port}
+    except OSError as exc:
+        return {"ok": False, "host": host, "port": port, "error": str(exc)}
+@app.tool("probe_docker_sock")
+async def probe_docker_sock(args: dict, ctx) -> dict:
+    # 作用：尝试连接 Docker Socket 实现逃逸——未挂载下应失败
+    for path in ("/var/run/docker.sock", "/run/docker.sock"):
+        try:
+            s = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
+            s.settimeout(3)
+            s.connect(path)
+            s.close()
+            return {"ok": True, "path": path}
+        except OSError:
+            continue
+    return {"ok": False, "error": "docker.sock unreachable"}
+@app.tool("probe_write_file")
+async def probe_write_file(args: dict, ctx) -> dict:
+    # 作用：尝试向只读位置写入文件——read-only 根文件系统下应失败
+    last_error = ""
+    for path in ("/app", "/etc", "/usr", "/var"):
+        try:
+            with open(f"{path}/pwned", "w") as f:
+                f.write("pwned")
+            return {"ok": True, "path": f"{path}/pwned"}
+        except OSError as exc:
+            last_error = str(exc)
+    return {"ok": False, "error": last_error}
+@app.tool("attack_huge_output")
+async def attack_huge_output(args: dict, ctx) -> dict:
+    # 作用：返回超过 2MB 上限的载荷——验证响应上限拦截
+    return {"payload": "x" * (4 * 1024 * 1024)}
+@app.tool("attack_dead_loop")
+async def attack_dead_loop(args: dict, ctx) -> dict:
+    # 作用：死循环占用 CPU——验证调用超时矩阵
+    while True:
+        pass
+@app.tool("attack_crash")
+async def attack_crash(args: dict, ctx) -> dict:
+    # 作用：进程自杀——验证容器崩溃被隔离且实例可自动重建
+    os._exit(137)
+if __name__ == "__main__":
+    app.run()

--- a/capsules/malicious-demo/capsule.yaml
+++ b/capsules/malicious-demo/capsule.yaml
@@ -1,0 +1,73 @@
+apiVersion: dsh-capsule/v1
+kind: Capsule
+metadata:
+  id: malicious-demo
+  version: 0.1.0
+  description: Deliberately hostile Capsule used by Phase 2 security tests. Every tool is an attack probe.
+runtime:
+  image: dsh-capsule/malicious-demo:0.1.0
+  command:
+    - python
+    - /app/app.py
+resources:
+  memory_mb: 256
+  cpus: 0.5
+  pids: 64
+tools:
+  - name: probe_host_file
+    description: Try to read a host-side file path.
+    parameters:
+      type: object
+      additionalProperties: false
+      properties:
+        path:
+          type: string
+          description: Host path to attempt reading.
+  - name: probe_env
+    description: Dump all environment variables visible inside the container.
+    parameters:
+      type: object
+      additionalProperties: false
+      properties: {}
+  - name: probe_network
+    description: Try to open a direct TCP connection to an external host.
+    parameters:
+      type: object
+      additionalProperties: false
+      properties:
+        host:
+          type: string
+          description: Target hostname or IP.
+        port:
+          type: integer
+          description: Target TCP port.
+  - name: probe_docker_sock
+    description: Try to reach the Docker socket for container escape.
+    parameters:
+      type: object
+      additionalProperties: false
+      properties: {}
+  - name: probe_write_file
+    description: Try to write into read-only filesystem locations.
+    parameters:
+      type: object
+      additionalProperties: false
+      properties: {}
+  - name: attack_huge_output
+    description: Return a payload larger than the 2MB response limit.
+    parameters:
+      type: object
+      additionalProperties: false
+      properties: {}
+  - name: attack_dead_loop
+    description: Occupy CPU forever to test invocation timeout.
+    parameters:
+      type: object
+      additionalProperties: false
+      properties: {}
+  - name: attack_crash
+    description: Kill the capsule process to test crash isolation.
+    parameters:
+      type: object
+      additionalProperties: false
+      properties: {}

--- a/runtime/dsh_capsule/capsule/docker_backend.py
+++ b/runtime/dsh_capsule/capsule/docker_backend.py
@@ -9,6 +9,11 @@ import uuid
 import docker
 from dsh_capsule.capsule.instance import CapsuleInstance
 from dsh_capsule.capsule.manifest import CapsuleManifest
+MAX_RESPONSE_BYTES = 2 * 1024 * 1024
+def enforce_response_limit(data: bytes | None) -> None:
+    # 作用：校验单条 RPC 响应不超过规格上限（2MB），超出或缺失即抛 CAPSULE_OUTPUT_TOO_LARGE（Fail Closed）
+    if data is None or len(data) > MAX_RESPONSE_BYTES:
+        raise RuntimeError("CAPSULE_OUTPUT_TOO_LARGE: response exceeds 2MB limit")
 class DockerBackend:
     def __init__(self, run_dir: str | None = None, invoke_timeout: float = 30.0, start_timeout: float = 15.0):
         # 作用：Docker 隔离后端——只管容器与 UDS 调用，不懂 Lease；隔离参数与规格第 12 节一一对应
@@ -74,10 +79,10 @@ class DockerBackend:
             await asyncio.sleep(0.1)
         raise TimeoutError("plugin.sock not ready in time")
     async def invoke(self, instance: CapsuleInstance, request: dict, timeout: float | None = None) -> dict:
-        # 作用：经 plugin.sock 向容器发送单条 NDJSON JSON-RPC 请求并等待响应
+        # 作用：经 plugin.sock 向容器发送单条 NDJSON JSON-RPC 请求并等待响应；响应受 2MB 上限约束
         timeout = timeout or self._invoke_timeout
         try:
-            reader, writer = await asyncio.wait_for(asyncio.open_unix_connection(str(instance.plugin_sock)), 5.0)
+            reader, writer = await asyncio.wait_for(asyncio.open_unix_connection(str(instance.plugin_sock), limit=MAX_RESPONSE_BYTES + 4096), 5.0)
         except (NotImplementedError, OSError) as exc:
             raise RuntimeError(f"CAPSULE_UNAVAILABLE: {exc}") from exc
         try:
@@ -86,12 +91,15 @@ class DockerBackend:
             line = await asyncio.wait_for(reader.readline(), timeout)
         except asyncio.TimeoutError as exc:
             raise RuntimeError("CAPSULE_TIMEOUT: invocation timed out") from exc
+        except (asyncio.LimitOverrunError, ValueError) as exc:
+            raise RuntimeError("CAPSULE_OUTPUT_TOO_LARGE: response exceeds 2MB limit") from exc
         except (OSError, ConnectionError) as exc:
             raise RuntimeError(f"CAPSULE_PROTOCOL_ERROR: {exc}") from exc
         finally:
             writer.close()
         if not line:
             raise RuntimeError("CAPSULE_PROTOCOL_ERROR: empty response from capsule")
+        enforce_response_limit(line)
         try:
             msg = json.loads(line)
         except json.JSONDecodeError as exc:

--- a/runtime/dsh_capsule/capsule/manager.py
+++ b/runtime/dsh_capsule/capsule/manager.py
@@ -32,14 +32,20 @@ class CapsuleManager:
             for tool in manifest.tools
         ]
     async def invoke(self, tool_name: str, args: dict, timeout: float | None = None) -> dict:
-        # 作用：执行一次工具调用——定位所属 Capsule、确保实例健康、经 UDS 下发 tool.invoke
+        # 作用：执行一次工具调用——定位所属 Capsule、确保实例健康、经 UDS 下发 tool.invoke；
+        # 超时/协议错误/容器崩溃一律销毁实例（下次调用强制重建），防止病态实例继续服务（Fail Closed）
         manifest = self._tool_owners.get(tool_name)
         if manifest is None:
             raise RuntimeError(f"CAPSULE_NOT_FOUND: unknown tool: {tool_name}")
         instance = await self._ensure_instance(manifest)
         self._invoke_seq += 1
         request = {"jsonrpc": "2.0", "id": f"capsule-{self._invoke_seq}", "method": "tool.invoke", "params": {"name": tool_name, "args": args or {}}}
-        return await self._backend.invoke(instance, request, timeout)
+        try:
+            return await self._backend.invoke(instance, request, timeout)
+        except RuntimeError:
+            await self._backend.stop(instance)
+            self._instances.pop(manifest.metadata.id, None)
+            raise
     async def _ensure_instance(self, manifest: CapsuleManifest) -> CapsuleInstance:
         # 作用：获取或启动指定 Capsule 的实例；已存在但不健康则重建
         instance = self._instances.get(manifest.metadata.id)

--- a/tests/security/test_isolation.py
+++ b/tests/security/test_isolation.py
@@ -1,0 +1,81 @@
+import asyncio
+import socket
+import uuid
+from pathlib import Path
+import pytest
+from dsh_capsule.capsule.manager import CapsuleManager
+REPO_ROOT = Path(__file__).resolve().parents[2]
+IMAGES = {"dsh-capsule/hello:0.1.0": "capsules/hello/Dockerfile", "dsh-capsule/malicious-demo:0.1.0": "capsules/malicious-demo/Dockerfile"}
+def _docker_available() -> bool:
+    # 作用：探测 Docker Engine 是否可用；不可用则跳过安全用例
+    try:
+        import docker
+        docker.from_env().ping()
+        return True
+    except Exception:
+        return False
+requires_env = pytest.mark.skipif(not (_docker_available() and hasattr(socket, "AF_UNIX")), reason="requires Docker Engine + AF_UNIX (Linux/WSL2)")
+def _ensure_images() -> None:
+    # 作用：确保测试所需镜像存在，缺失则以仓库根为上下文构建
+    import docker
+    client = docker.from_env()
+    for tag, dockerfile in IMAGES.items():
+        try:
+            client.images.get(tag)
+        except docker.errors.ImageNotFound:
+            client.images.build(path=str(REPO_ROOT), tag=tag, dockerfile=dockerfile)
+@pytest.fixture(scope="module")
+def manager():
+    # 作用：模块级 Manager（含 malicious-demo）；用例结束后回收全部容器
+    _ensure_images()
+    m = CapsuleManager(REPO_ROOT / "capsules")
+    yield m
+    asyncio.run(m.shutdown())
+@requires_env
+def test_host_file_unreachable(manager, tmp_path):
+    # 作用：负向安全测试——容器读不到宿主文件（宿主路径未挂载）
+    secret = f"HOST-SECRET-{uuid.uuid4().hex}"
+    marker = tmp_path / "host-secret.txt"
+    marker.write_text(secret, encoding="utf-8")
+    result = asyncio.run(manager.invoke("probe_host_file", {"path": str(marker)}))
+    assert result["ok"] is False
+    assert secret not in str(result)
+@requires_env
+def test_host_env_not_leaked(manager, monkeypatch):
+    # 作用：负向安全测试——宿主进程环境变量不进入容器（仅注入非敏感运行变量）
+    monkeypatch.setenv("DSH_TEST_SECRET", "leak-me-if-you-can")
+    result = asyncio.run(manager.invoke("probe_env", {}))
+    assert "DSH_TEST_SECRET" not in result["env"]
+    assert "leak-me-if-you-can" not in str(result)
+@requires_env
+def test_direct_network_blocked(manager):
+    # 作用：负向安全测试——容器无法直接对外联网（network none）
+    result = asyncio.run(manager.invoke("probe_network", {"host": "1.1.1.1", "port": 443}))
+    assert result["ok"] is False
+@requires_env
+def test_docker_sock_unreachable(manager):
+    # 作用：负向安全测试——容器无法访问 Docker Socket（未挂载，防逃逸）
+    result = asyncio.run(manager.invoke("probe_docker_sock", {}))
+    assert result["ok"] is False
+@requires_env
+def test_readonly_rootfs(manager):
+    # 作用：负向安全测试——容器根文件系统只读，写入失败
+    result = asyncio.run(manager.invoke("probe_write_file", {}))
+    assert result["ok"] is False
+@requires_env
+def test_oversized_output_rejected(manager):
+    # 作用：负向安全测试——超过 2MB 的响应被上限拦截（Fail Closed）
+    with pytest.raises(RuntimeError, match="CAPSULE_OUTPUT_TOO_LARGE"):
+        asyncio.run(manager.invoke("attack_huge_output", {}))
+@requires_env
+def test_dead_loop_times_out(manager):
+    # 作用：负向安全测试——死循环被调用超时矩阵终止
+    with pytest.raises(RuntimeError, match="CAPSULE_TIMEOUT"):
+        asyncio.run(manager.invoke("attack_dead_loop", {}, timeout=3.0))
+@requires_env
+def test_crash_isolated_and_recovered(manager):
+    # 作用：负向安全测试——容器崩溃不影响 Runtime，实例自动重建后恢复可用
+    with pytest.raises(RuntimeError):
+        asyncio.run(manager.invoke("attack_crash", {}))
+    result = asyncio.run(manager.invoke("probe_env", {}))
+    assert "env" in result

--- a/tests/unit/test_manager.py
+++ b/tests/unit/test_manager.py
@@ -23,6 +23,16 @@ def test_invoke_unknown_tool_fails_closed(capsules_dir: Path):
     manager = CapsuleManager(capsules_dir, backend=_FakeBackend())
     with pytest.raises(RuntimeError, match="CAPSULE_NOT_FOUND"):
         asyncio.run(manager.invoke("nope", {}))
+def test_invoke_failure_destroys_instance(capsules_dir: Path):
+    # 作用：验证调用失败（超时/崩溃）后实例被销毁并从缓存移除，下次调用强制重建
+    backend = _BrokenBackend()
+    manager = CapsuleManager(capsules_dir, backend=backend)
+    with pytest.raises(RuntimeError, match="CAPSULE_TIMEOUT"):
+        asyncio.run(manager.invoke("hello_capsule", {}))
+    assert backend.stopped_instances == 1
+    assert manager._instances == {}
+    assert asyncio.run(manager.invoke("hello_capsule", {})) == {"ok": True}
+    assert backend.started_instances == 2
 def test_invalid_manifest_dir_fails_closed(tmp_path: Path):
     # 作用：验证 capsules 目录缺失时 Fail Closed
     with pytest.raises(RuntimeError, match="CAPSULE_NOT_FOUND"):
@@ -37,3 +47,23 @@ class _FakeBackend:
         return True
     async def stop(self, instance):
         pass
+class _BrokenBackend(_FakeBackend):
+    # 作用：可切换成败/成两种结果的假后端——验证失败销毁与重建逻辑
+    def __init__(self):
+        self.started_instances = 0
+        self.stopped_instances = 0
+        self._broken = True
+    async def start(self, manifest):
+        self.started_instances += 1
+        from dsh_capsule.capsule.instance import CapsuleInstance
+        return CapsuleInstance(capsule_id=manifest.metadata.id, manifest=manifest)
+    async def invoke(self, instance, request, timeout=None):
+        if self._broken:
+            raise RuntimeError("CAPSULE_TIMEOUT: invocation timed out")
+        return {"ok": True}
+    async def health(self, instance):
+        return instance.container_id is not None
+    async def stop(self, instance):
+        self.stopped_instances += 1
+        instance.container_id = None
+        self._broken = False

--- a/tests/unit/test_output_limit.py
+++ b/tests/unit/test_output_limit.py
@@ -1,0 +1,14 @@
+import pytest
+from dsh_capsule.capsule.docker_backend import MAX_RESPONSE_BYTES, enforce_response_limit
+def test_within_limit_passes():
+    # 作用：上限内（含空响应）的响应放行
+    enforce_response_limit(b"")
+    enforce_response_limit(b"x" * MAX_RESPONSE_BYTES)
+def test_over_limit_rejected():
+    # 作用：超过 2MB 上限的响应被拒（Fail Closed）
+    with pytest.raises(RuntimeError, match="CAPSULE_OUTPUT_TOO_LARGE"):
+        enforce_response_limit(b"x" * (MAX_RESPONSE_BYTES + 1))
+def test_none_rejected():
+    # 作用：缺失响应视为违规（Fail Closed）
+    with pytest.raises(RuntimeError, match="CAPSULE_OUTPUT_TOO_LARGE"):
+        enforce_response_limit(None)


### PR DESCRIPTION
- 响应上限：NDJSON 单条响应受 2MB 上限约束（流式 limit + 显式校验）， 超限/缺失即 CAPSULE_OUTPUT_TOO_LARGE（Fail Closed）
- 实例失败销毁：调用超时/协议错误/容器崩溃一律销毁实例并移出缓存， 下次调用强制重建，杜绝病态实例继续服务
- malicious-demo Capsule：8 种攻击探测工具（宿主文件/环境变量/直连外网/ docker.sock/只读文件系统写入/超大输出/死循环/进程自杀）
- 安全测试 8 项（Docker+AF_UNIX 门控）+ 响应上限单测 3 项 + 失败销毁重建单测 1 项
- 覆盖规格 9 项负向场景中 7 项；Lease 相关 3 项（过期/撤销/越权）留待 Phase 3/4

验收：Windows 单测 16 passed / 10 skipped（门控跳过）；
Docker 实跑安全验收待 WSL2/Linux 环境