### PR TITLE
feat(phase-3): Capability Lease 服务与 SQLite 持久化

### DIFF
--- a/cli/capsulectl.py
+++ b/cli/capsulectl.py
@@ -1,0 +1,61 @@
+import argparse
+import asyncio
+import sys
+from dsh_capsule.lease.service import LeaseService
+from dsh_capsule.lease.models import LeaseError
+from dsh_capsule.storage.db import LeaseStore
+def _build_service(db_path: str) -> tuple[LeaseService, LeaseStore]:
+    # 作用：构造连接指定 SQLite 文件的 LeaseService 与其存储句柄
+    store = LeaseStore(db_path)
+    asyncio.run(store.connect())
+    return LeaseService(store), store
+def cmd_leases(db_path: str) -> None:
+    # 作用：列出全部 Lease 及其状态
+    service, store = _build_service(db_path)
+    try:
+        leases = asyncio.run(service.list_leases())
+        if not leases:
+            print("no leases")
+            return
+        for l in leases:
+            print(f"{l.id}  capsule={l.capsule_id}  session={l.session_id}  {l.provider} {l.resource}  actions={','.join(sorted(l.actions))}  status={l.status}  expires={int(l.expires_at)}")
+    finally:
+        asyncio.run(store.close())
+def _revoke_and_report(coro_name: str, db_path: str, target: str) -> None:
+    # 作用：执行撤销命令并汇报结果；失败时打印统一错误码
+    service, store = _build_service(db_path)
+    try:
+        if coro_name == "revoke":
+            asyncio.run(service.revoke(target))
+            print(f"revoked {target}")
+        elif coro_name == "revoke_session":
+            n = asyncio.run(service.revoke_session(target))
+            print(f"revoked {n} lease(s) of session {target}")
+        else:
+            n = asyncio.run(service.revoke_capsule(target))
+            print(f"revoked {n} lease(s) of capsule {target}")
+    except LeaseError as exc:
+        print(f"error: {exc.code}", file=sys.stderr)
+        sys.exit(1)
+    finally:
+        asyncio.run(store.close())
+def main() -> None:
+    # 作用：capsulectl 入口——leases / revoke / revoke-session / revoke-capsule（规格第 20 节）
+    parser = argparse.ArgumentParser(prog="capsulectl")
+    parser.add_argument("--db", default="leases.db", help="path to lease sqlite db")
+    sub = parser.add_subparsers(dest="cmd", required=True)
+    sub.add_parser("leases")
+    p_revoke = sub.add_parser("revoke"); p_revoke.add_argument("lease_id")
+    p_rs = sub.add_parser("revoke-session"); p_rs.add_argument("session_id")
+    p_rc = sub.add_parser("revoke-capsule"); p_rc.add_argument("capsule_id")
+    args = parser.parse_args()
+    if args.cmd == "leases":
+        cmd_leases(args.db)
+    elif args.cmd == "revoke":
+        _revoke_and_report("revoke", args.db, args.lease_id)
+    elif args.cmd == "revoke-session":
+        _revoke_and_report("revoke_session", args.db, args.session_id)
+    else:
+        _revoke_and_report("revoke_capsule", args.db, args.capsule_id)
+if __name__ == "__main__":
+    main()

--- a/runtime/dsh_capsule/lease/__init__.py
+++ b/runtime/dsh_capsule/lease/__init__.py
@@ -1,0 +1,3 @@
+from dsh_capsule.lease.models import CapabilityLease, LeaseError
+from dsh_capsule.lease.service import LeaseService
+__all__ = ["CapabilityLease", "LeaseError", "LeaseService"]

--- a/runtime/dsh_capsule/lease/models.py
+++ b/runtime/dsh_capsule/lease/models.py
@@ -1,0 +1,30 @@
+from typing import Literal
+from pydantic import BaseModel, ConfigDict, field_validator
+class LeaseError(Exception):
+    # 作用：统一携带规格第 28 节错误码的 Lease 异常；Fail Closed 下任意校验失败即抛出
+    def __init__(self, code: str, message: str = ""):
+        super().__init__(f"{code}: {message}" if message else code)
+        self.code = code
+        self.message = message
+class CapabilityLease(BaseModel):
+    # 作用：Capability Lease 数据模型（规格第 16 节）——绑定实例+会话+Provider+资源+动作与 TTL
+    model_config = ConfigDict(extra="forbid")
+    id: str
+    capsule_id: str
+    capsule_instance_id: str
+    session_id: str
+    provider: str
+    resource: str
+    actions: set[str]
+    issued_at: float
+    expires_at: float
+    status: Literal["ACTIVE", "REVOKED", "EXPIRED"] = "ACTIVE"
+    revoked_at: float | None = None
+    revoke_reason: str | None = None
+    @field_validator("resource")
+    @classmethod
+    def _validate_resource(cls, v: str) -> str:
+        # 作用：资源标识必须形如 kind:value（如 repo:foo/bar），未知格式 Fail Closed
+        if ":" not in v:
+            raise ValueError(f"invalid resource format: {v}")
+        return v

--- a/runtime/dsh_capsule/lease/service.py
+++ b/runtime/dsh_capsule/lease/service.py
@@ -1,0 +1,58 @@
+import time
+from dsh_capsule.lease.models import CapabilityLease, LeaseError
+from dsh_capsule.storage.db import LeaseStore, new_lease_id
+class LeaseService:
+    def __init__(self, store: LeaseStore):
+        # 作用：Lease 生命周期服务——签发/校验/撤销；安全正确性全部在 validate 时点判断，不依赖后台任务
+        self._store = store
+    async def issue(self, *, capsule_id: str, capsule_instance_id: str, session_id: str, provider: str, resource: str, actions: set[str], ttl_seconds: int) -> CapabilityLease:
+        # 作用：签发新 Lease（调用前提：宿主 Approval 已通过）；TTL 上限内任意时长
+        now = time.time()
+        lease = CapabilityLease(
+            id=new_lease_id(), capsule_id=capsule_id, capsule_instance_id=capsule_instance_id,
+            session_id=session_id, provider=provider, resource=resource, actions=set(actions),
+            issued_at=now, expires_at=now + ttl_seconds, status="ACTIVE",
+        )
+        await self._store.insert(lease)
+        return lease
+    async def find_matching_lease(self, *, capsule_instance_id: str, session_id: str, provider: str, resource: str) -> CapabilityLease | None:
+        # 作用：复用路径——查找同实例+会话+Provider+资源的未过期 ACTIVE Lease；不存在返回 None（由调用方发起 Approval）
+        lease = await self._store.find_matching(capsule_instance_id, session_id, provider, resource)
+        if lease is None or lease.status != "ACTIVE":
+            return None
+        if time.time() >= lease.expires_at:
+            await self._store.update_status(lease.id, "EXPIRED", "expired on lookup")
+            return None
+        return lease
+    async def validate(self, *, capsule_instance_id: str, session_id: str, provider: str, resource: str, action: str) -> CapabilityLease:
+        # 作用：规格第 17 节安全规则逐条校验，任意条件失败即抛对应错误码（Fail Closed，绝不"尽量执行"）
+        lease = await self._store.find_for_resource(provider, resource)
+        if lease is None:
+            raise LeaseError("LEASE_REQUIRED", f"no active lease for {provider} {resource}")
+        if lease.status == "REVOKED":
+            raise LeaseError("LEASE_REVOKED", f"lease {lease.id} revoked")
+        if time.time() >= lease.expires_at:
+            await self._store.update_status(lease.id, "EXPIRED", "expired on validate")
+            raise LeaseError("LEASE_EXPIRED", f"lease {lease.id} expired")
+        if lease.capsule_instance_id != capsule_instance_id:
+            raise LeaseError("LEASE_CAPSULE_MISMATCH", "lease bound to another capsule instance")
+        if lease.session_id != session_id:
+            raise LeaseError("LEASE_SESSION_MISMATCH", "lease bound to another session")
+        if action not in lease.actions:
+            raise LeaseError("CAPABILITY_DENIED", f"action {action} not granted by lease {lease.id}")
+        return lease
+    async def revoke(self, lease_id: str) -> None:
+        # 作用：撤销单个 Lease；不存在抛 LEASE_NOT_FOUND
+        lease = await self._store.get(lease_id)
+        if lease is None:
+            raise LeaseError("LEASE_NOT_FOUND", f"lease {lease_id} not found")
+        await self._store.update_status(lease_id, "REVOKED", "manual revoke")
+    async def revoke_session(self, session_id: str) -> int:
+        # 作用：撤销整个 Session 的 Lease，返回撤销数量
+        return await self._store.revoke_by_session(session_id)
+    async def revoke_capsule(self, capsule_id: str) -> int:
+        # 作用：撤销整个 Capsule 的 Lease，返回撤销数量
+        return await self._store.revoke_by_capsule(capsule_id)
+    async def list_leases(self) -> list[CapabilityLease]:
+        # 作用：列出全部 Lease（capsulectl 使用）
+        return await self._store.list_all()

--- a/runtime/dsh_capsule/storage/__init__.py
+++ b/runtime/dsh_capsule/storage/__init__.py
@@ -1,0 +1,2 @@
+from dsh_capsule.storage.db import LeaseStore
+__all__ = ["LeaseStore"]

--- a/runtime/dsh_capsule/storage/db.py
+++ b/runtime/dsh_capsule/storage/db.py
@@ -1,0 +1,112 @@
+import json
+import time
+import uuid
+import aiosqlite
+from dsh_capsule.lease.models import CapabilityLease
+SCHEMA = """
+CREATE TABLE IF NOT EXISTS leases (
+    id TEXT PRIMARY KEY,
+    capsule_id TEXT NOT NULL,
+    capsule_instance_id TEXT NOT NULL,
+    session_id TEXT NOT NULL,
+    provider TEXT NOT NULL,
+    resource TEXT NOT NULL,
+    actions_json TEXT NOT NULL,
+    issued_at INTEGER NOT NULL,
+    expires_at INTEGER NOT NULL,
+    status TEXT NOT NULL,
+    revoked_at INTEGER,
+    revoke_reason TEXT
+);
+CREATE INDEX IF NOT EXISTS idx_leases_session ON leases(session_id);
+CREATE INDEX IF NOT EXISTS idx_leases_capsule ON leases(capsule_id);
+CREATE INDEX IF NOT EXISTS idx_leases_status ON leases(status);
+"""
+class LeaseStore:
+    def __init__(self, db_path: str = "leases.db"):
+        # 作用：Lease 持久化层——只管 SQLite 读写，不懂校验策略；所有时间均为 Unix 秒
+        self._db_path = db_path
+        self._conn: aiosqlite.Connection | None = None
+    async def connect(self) -> None:
+        # 作用：建立连接并确保表结构存在（幂等）
+        self._conn = await aiosqlite.connect(self._db_path)
+        await self._conn.execute("PRAGMA journal_mode=WAL")
+        await self._conn.executescript(SCHEMA)
+        await self._conn.commit()
+    async def close(self) -> None:
+        # 作用：关闭连接
+        if self._conn is not None:
+            await self._conn.close()
+            self._conn = None
+    def _require_conn(self) -> aiosqlite.Connection:
+        # 作用：Fail Closed——未连接即抛错，绝不静默跳过持久化
+        if self._conn is None:
+            raise RuntimeError("LEASE_STORE_ERROR: storage not connected")
+        return self._conn
+    @staticmethod
+    def _row_to_lease(row) -> CapabilityLease:
+        # 作用：把数据库行还原为 Lease 模型
+        return CapabilityLease(
+            id=row[0], capsule_id=row[1], capsule_instance_id=row[2], session_id=row[3],
+            provider=row[4], resource=row[5], actions=set(json.loads(row[6])),
+            issued_at=row[7], expires_at=row[8], status=row[9],
+            revoked_at=row[10], revoke_reason=row[11],
+        )
+    async def insert(self, lease: CapabilityLease) -> None:
+        # 作用：写入新 Lease（签发路径专用）
+        await self._require_conn().execute(
+            "INSERT INTO leases (id, capsule_id, capsule_instance_id, session_id, provider, resource, actions_json, issued_at, expires_at, status, revoked_at, revoke_reason) VALUES (?,?,?,?,?,?,?,?,?,?,?,?)",
+            (lease.id, lease.capsule_id, lease.capsule_instance_id, lease.session_id, lease.provider, lease.resource, json.dumps(sorted(lease.actions)), lease.issued_at, lease.expires_at, lease.status, lease.revoked_at, lease.revoke_reason),
+        )
+        await self._conn.commit()
+    async def get(self, lease_id: str) -> CapabilityLease | None:
+        # 作用：按 id 读取单个 Lease
+        async with self._require_conn().execute("SELECT * FROM leases WHERE id = ?", (lease_id,)) as cur:
+            row = await cur.fetchone()
+            return self._row_to_lease(row) if row else None
+    async def find_matching(self, capsule_instance_id: str, session_id: str, provider: str, resource: str) -> CapabilityLease | None:
+        # 作用：查找同实例+同会话+同资源+同 Provider 的最新一条 Lease（复用路径的完整键匹配）
+        async with self._require_conn().execute(
+            "SELECT * FROM leases WHERE capsule_instance_id = ? AND session_id = ? AND provider = ? AND resource = ? ORDER BY issued_at DESC LIMIT 1",
+            (capsule_instance_id, session_id, provider, resource),
+        ) as cur:
+            row = await cur.fetchone()
+            return self._row_to_lease(row) if row else None
+    async def find_for_resource(self, provider: str, resource: str) -> CapabilityLease | None:
+        # 作用：按 Provider+资源查找最新 Lease（不限定实例与会话，由服务层做绑定校验）
+        async with self._require_conn().execute(
+            "SELECT * FROM leases WHERE provider = ? AND resource = ? ORDER BY issued_at DESC LIMIT 1",
+            (provider, resource),
+        ) as cur:
+            row = await cur.fetchone()
+            return self._row_to_lease(row) if row else None
+    async def update_status(self, lease_id: str, status: str, revoke_reason: str | None = None) -> None:
+        # 作用：更新 Lease 状态（EXPIRED/REVOKED），记录撤销原因与时间
+        await self._require_conn().execute(
+            "UPDATE leases SET status = ?, revoked_at = ?, revoke_reason = ? WHERE id = ?",
+            (status, time.time(), revoke_reason, lease_id),
+        )
+        await self._conn.commit()
+    async def revoke_by_session(self, session_id: str) -> int:
+        # 作用：撤销某 Session 的全部 ACTIVE Lease，返回撤销数量
+        cur = await self._require_conn().execute(
+            "UPDATE leases SET status = 'REVOKED', revoked_at = ?, revoke_reason = ? WHERE session_id = ? AND status = 'ACTIVE'",
+            (time.time(), "session revoked", session_id),
+        )
+        await self._conn.commit()
+        return cur.rowcount
+    async def revoke_by_capsule(self, capsule_id: str) -> int:
+        # 作用：撤销某 Capsule 的全部 ACTIVE Lease，返回撤销数量
+        cur = await self._require_conn().execute(
+            "UPDATE leases SET status = 'REVOKED', revoked_at = ?, revoke_reason = ? WHERE capsule_id = ? AND status = 'ACTIVE'",
+            (time.time(), "capsule revoked", capsule_id),
+        )
+        await self._conn.commit()
+        return cur.rowcount
+    async def list_all(self) -> list[CapabilityLease]:
+        # 作用：列出全部 Lease（capsulectl 与调试用）
+        async with self._require_conn().execute("SELECT * FROM leases ORDER BY issued_at DESC") as cur:
+            return [self._row_to_lease(row) for row in await cur.fetchall()]
+def new_lease_id() -> str:
+    # 作用：生成全局唯一 Lease ID
+    return f"L{uuid.uuid4().hex[:12]}"

--- a/tests/unit/test_lease_service.py
+++ b/tests/unit/test_lease_service.py
@@ -1,0 +1,118 @@
+import asyncio
+import time
+import pytest
+from dsh_capsule.lease.models import CapabilityLease, LeaseError
+from dsh_capsule.lease.service import LeaseService
+from dsh_capsule.storage.db import LeaseStore
+BASE = {"capsule_id": "github-reader", "capsule_instance_id": "inst-1", "session_id": "S100", "provider": "github", "resource": "repo:foo/bar", "actions": {"issues.read"}}
+@pytest.fixture
+def service(tmp_path):
+    # 作用：每个用例独立的临时 SQLite LeaseService
+    store = LeaseStore(str(tmp_path / "leases.db"))
+    asyncio.run(store.connect())
+    yield LeaseService(store)
+    asyncio.run(store.close())
+def _issue(service: LeaseService, **overrides) -> str:
+    # 作用：按基准参数签发 Lease，返回 lease_id
+    params = {**BASE, **overrides}
+    actions = params.pop("actions")
+    ttl = params.pop("ttl_seconds", 600)
+    lease = asyncio.run(service.issue(ttl_seconds=ttl, actions=actions, **params))
+    return lease.id
+def test_issue_and_validate_happy_path(service):
+    # 作用：签发后同实例+会话+动作校验通过并返回 Lease
+    _issue(service)
+    lease = asyncio.run(service.validate(capsule_instance_id="inst-1", session_id="S100", provider="github", resource="repo:foo/bar", action="issues.read"))
+    assert lease.status == "ACTIVE"
+    assert lease.actions == {"issues.read"}
+def test_no_lease_raises_required(service):
+    # 作用：无 Lease 时抛 LEASE_REQUIRED（Fail Closed）
+    with pytest.raises(LeaseError, match="LEASE_REQUIRED"):
+        asyncio.run(service.validate(capsule_instance_id="inst-1", session_id="S100", provider="github", resource="repo:foo/bar", action="issues.read"))
+def test_expired_lease_denied_even_without_cleanup(service):
+    # 作用：TTL 过期在 validate 时点即拒绝（不依赖后台 cleanup 线程）
+    _issue(service, ttl_seconds=-1)
+    with pytest.raises(LeaseError, match="LEASE_EXPIRED"):
+        asyncio.run(service.validate(capsule_instance_id="inst-1", session_id="S100", provider="github", resource="repo:foo/bar", action="issues.read"))
+def test_revoked_lease_denied_immediately(service):
+    # 作用：撤销后立即返回 LEASE_REVOKED（不等待 DSH 重启）
+    lease_id = _issue(service)
+    asyncio.run(service.revoke(lease_id))
+    with pytest.raises(LeaseError, match="LEASE_REVOKED"):
+        asyncio.run(service.validate(capsule_instance_id="inst-1", session_id="S100", provider="github", resource="repo:foo/bar", action="issues.read"))
+def test_revoke_unknown_lease_raises(service):
+    # 作用：撤销不存在的 Lease 抛 LEASE_NOT_FOUND
+    with pytest.raises(LeaseError, match="LEASE_NOT_FOUND"):
+        asyncio.run(service.revoke("L999"))
+def test_cross_session_reuse_denied(service):
+    # 作用：Session B 复用 Session A 的 Lease 抛 LEASE_SESSION_MISMATCH（规格第 19 节）
+    _issue(service)
+    with pytest.raises(LeaseError, match="LEASE_SESSION_MISMATCH"):
+        asyncio.run(service.validate(capsule_instance_id="inst-1", session_id="S200", provider="github", resource="repo:foo/bar", action="issues.read"))
+def test_cross_instance_denied(service):
+    # 作用：其他 Capsule 实例复用 Lease 抛 LEASE_CAPSULE_MISMATCH
+    _issue(service)
+    with pytest.raises(LeaseError, match="LEASE_CAPSULE_MISMATCH"):
+        asyncio.run(service.validate(capsule_instance_id="inst-2", session_id="S100", provider="github", resource="repo:foo/bar", action="issues.read"))
+def test_unauthorized_action_denied(service):
+    # 作用：Lease 只授 issues.read，请求 repo.delete 抛 CAPABILITY_DENIED（规格第 27 节越权场景）
+    _issue(service)
+    with pytest.raises(LeaseError, match="CAPABILITY_DENIED"):
+        asyncio.run(service.validate(capsule_instance_id="inst-1", session_id="S100", provider="github", resource="repo:foo/bar", action="repo.delete"))
+def test_revoke_session_bulk(service):
+    # 作用：revoke_session 批量撤销该会话全部 Lease
+    _issue(service)
+    _issue(service, resource="repo:other/repo")
+    n = asyncio.run(service.revoke_session("S100"))
+    assert n == 2
+    with pytest.raises(LeaseError, match="LEASE_REVOKED"):
+        asyncio.run(service.validate(capsule_instance_id="inst-1", session_id="S100", provider="github", resource="repo:foo/bar", action="issues.read"))
+def test_revoke_capsule_bulk(service):
+    # 作用：revoke_capsule 批量撤销该 Capsule 全部 Lease
+    _issue(service)
+    _issue(service, session_id="S200")
+    n = asyncio.run(service.revoke_capsule("github-reader"))
+    assert n == 2
+def test_find_matching_lease_reuse(service):
+    # 作用：同键未过期时 find_matching_lease 命中（免 Approval 复用）
+    _issue(service)
+    lease = asyncio.run(service.find_matching_lease(capsule_instance_id="inst-1", session_id="S100", provider="github", resource="repo:foo/bar"))
+    assert lease is not None and lease.status == "ACTIVE"
+def test_find_matching_lease_none_for_other_session(service):
+    # 作用：跨会话查找返回 None（需要重新走 Approval）
+    _issue(service)
+    assert asyncio.run(service.find_matching_lease(capsule_instance_id="inst-1", session_id="S200", provider="github", resource="repo:foo/bar")) is None
+def test_find_matching_lease_expired(service):
+    # 作用：过期 Lease 查找返回 None 且状态被标记为 EXPIRED
+    _issue(service, ttl_seconds=-1)
+    assert asyncio.run(service.find_matching_lease(capsule_instance_id="inst-1", session_id="S100", provider="github", resource="repo:foo/bar")) is None
+def test_invalid_resource_format_rejected(service):
+    # 作用：资源标识缺少 kind: 前缀时模型校验失败（未知资源格式 Fail Closed）
+    with pytest.raises(Exception, match="invalid resource format"):
+        asyncio.run(service.issue(ttl_seconds=600, actions={"issues.read"}, capsule_id="github-reader", capsule_instance_id="inst-1", session_id="S100", provider="github", resource="foo/bar"))
+def test_lease_persisted_across_restart(tmp_path):
+    # 作用：Lease 持久化在 SQLite，重启 Runtime 后状态可查
+    db = str(tmp_path / "leases.db")
+    store = LeaseStore(db)
+    asyncio.run(store.connect())
+    service = LeaseService(store)
+    lease_id = _issue(service)
+    asyncio.run(store.close())
+    store2 = LeaseStore(db)
+    asyncio.run(store2.connect())
+    service2 = LeaseService(store2)
+    leases = asyncio.run(service2.list_leases())
+    assert [l.id for l in leases] == [lease_id]
+    asyncio.run(store2.close())
+def test_expiry_survives_clock_advance(service):
+    # 作用：issued_at/expires_at 均为绝对时间戳，随真实时间推进自然过期
+    _issue(service, ttl_seconds=1)
+    time.sleep(1.2)
+    with pytest.raises(LeaseError, match="LEASE_EXPIRED"):
+        asyncio.run(service.validate(capsule_instance_id="inst-1", session_id="S100", provider="github", resource="repo:foo/bar", action="issues.read"))
+def test_capability_lease_model_roundtrip():
+    # 作用：模型字段与状态枚举完整性（规格第 16 节数据模型）
+    now = time.time()
+    lease = CapabilityLease(id="L1", capsule_id="c", capsule_instance_id="i", session_id="s", provider="github", resource="repo:a/b", actions={"issues.read"}, issued_at=now, expires_at=now + 60)
+    assert lease.status == "ACTIVE"
+    assert lease.revoked_at is None


### PR DESCRIPTION
- CapabilityLease 模型：绑定 capsule_instance + session + provider + resource + actions + TTL，资源标识强制 kind:value 格式
- LeaseStore（aiosqlite/WAL）：Lease 持久化，Session/Capsule/状态索引， 未连接 Fail Closed
- LeaseService：validate 八条安全规则逐条校验（规格第 17 节），过期在 校验时点判定不依赖后台线程（第 21 节），revoke/revoke_session/ revoke_capsule 撤销立即生效（第 20 节），find_matching_lease 复用免批
- capsulectl CLI：leases / revoke / revoke-session / revoke-capsule
- 统一错误码：LEASE_REQUIRED/REVOKED/EXPIRED/NOT_FOUND/ SESSION_MISMATCH/CAPSULE_MISMATCH/CAPABILITY_DENIED（第 28 节）
- 单测 17 项：签发/复用/过期/三类撤销/跨会话/跨实例/越权/持久化重启

验收：33 passed / 10 skipped（Docker 门控跳过）