### PR TITLE
feat(phase-4): DSH Approval + Credentials 反向 RPC 集成

### DIFF
--- a/adapter/src/approval.test.ts
+++ b/adapter/src/approval.test.ts
@@ -1,0 +1,50 @@
+import { describe, expect, it } from "vitest";
+import { createLeaseApprovalHandler, getApprovalService, type DshApprovalService } from "./approval.js";
+const baseReq = { capsuleId: "github-reader", provider: "github", resource: "repo:foo/bar", action: "issues.read", ttlSeconds: 600 };
+function approvalReturning(result: unknown): { service: DshApprovalService; calls: any[] } {
+  // 作用：构造记录调用参数的假 DSH approval 服务
+  const calls: any[] = [];
+  return { calls, service: { request: async (req: any) => { calls.push(req); return result; } } };
+}
+describe("createLeaseApprovalHandler", () => {
+  it("allowed-once 决策放行并回传 decision，reason 含完整授权信息", async () => {
+    const { service, calls } = approvalReturning("allowed-once");
+    await expect(createLeaseApprovalHandler(() => service)({ ...baseReq })).resolves.toEqual({ decision: "allowed-once" });
+    expect(calls[0].reason).toContain("github-reader");
+    expect(calls[0].reason).toContain("issues.read");
+    expect(calls[0].reason).toContain("repo:foo/bar");
+    expect(calls[0].reason).toContain("600");
+  });
+  it("对象形 decision=allowed-once 同样放行（规则 15：以实际 DSH 返回形状为准）", async () => {
+    const { service } = approvalReturning({ decision: "allowed-once" });
+    await expect(createLeaseApprovalHandler(() => service)({ ...baseReq })).resolves.toEqual({ decision: "allowed-once" });
+  });
+  it("rejected/cancelled/unavailable 决策一律拒绝（Fail Closed）", async () => {
+    for (const decision of ["rejected", "cancelled", "unavailable"]) {
+      const { service } = approvalReturning(decision);
+      await expect(createLeaseApprovalHandler(() => service)({ ...baseReq })).rejects.toThrow("LEASE_REJECTED");
+    }
+  });
+  it("approval 服务不可用即拒绝", async () => {
+    await expect(createLeaseApprovalHandler(() => undefined)({ ...baseReq })).rejects.toThrow("LEASE_REJECTED");
+  });
+  it("参数缺失或非法拒绝（Fail Closed）", async () => {
+    const { service } = approvalReturning("allowed-once");
+    const handler = createLeaseApprovalHandler(() => service);
+    await expect(handler({ ...baseReq, resource: undefined })).rejects.toThrow("LEASE_REJECTED");
+    await expect(handler({ ...baseReq, capsuleId: "" })).rejects.toThrow("LEASE_REJECTED");
+    await expect(handler({ ...baseReq, ttlSeconds: 0 })).rejects.toThrow("LEASE_REJECTED");
+    await expect(handler({ ...baseReq, ttlSeconds: 10.5 })).rejects.toThrow("LEASE_REJECTED");
+    await expect(handler(null)).rejects.toThrow("LEASE_REJECTED");
+  });
+});
+describe("getApprovalService", () => {
+  it("从 ctx 定位 approval 服务", () => {
+    expect(getApprovalService({ approval: { request: async () => "allowed-once" } })).toBeDefined();
+  });
+  it("形状不符或缺失时返回 undefined（Fail Closed）", () => {
+    expect(getApprovalService({})).toBeUndefined();
+    expect(getApprovalService({ approval: {} })).toBeUndefined();
+    expect(getApprovalService({ approval: "nope" })).toBeUndefined();
+  });
+});

--- a/adapter/src/approval.ts
+++ b/adapter/src/approval.ts
@@ -1,12 +1,50 @@
-// TODO(Phase 4): 集成 DSH ctx.approval，仅接受 allowed-once，其余结果一律拒绝（Fail Closed）
+import type { HostHandler } from "./rpc-client.js";
+// 作用：DSH Approval 集成（规格第 33 节）——宿主 one-shot Approval 批准的是"签发一张明确 Scope、明确 TTL 的 Lease"，
+// 仅接受 allowed-once，其余结果（rejected/cancelled/unavailable）一律拒绝（Fail Closed）。
 export interface LeaseApprovalRequest {
   capsuleId: string;
   provider: string;
   resource: string;
   action: string;
   ttlSeconds: number;
+  toolName?: string;
 }
-export async function requestLeaseApproval(_req: LeaseApprovalRequest): Promise<"allowed-once"> {
-  // 作用：预留的 Lease 签发授权入口（Phase 4 实现）
-  throw new Error("not implemented until Phase 4");
+export interface DshApprovalService {
+  // TODO(Phase 4, 规则 15)：DSH ctx.approval 的确切形状以当前安装版本官方 TypeScript 类型定义与官方文档为准，
+  // 本接口仅按技术规格第 33 节声明 request({ agent, toolName, callId, reason })；接入真实 DSH 时需逐字段核对。
+  request(req: { agent?: unknown; toolName?: string; callId?: unknown; reason?: string }): Promise<unknown>;
+}
+export function getApprovalService(ctx: Record<string, unknown>): DshApprovalService | undefined {
+  // 作用：从 DSH ctx 上定位 approval 服务；形状不符（无 request 方法）即视为不可用（Fail Closed）
+  const approval = ctx["approval"];
+  if (typeof approval === "object" && approval !== null && typeof (approval as any).request === "function") {
+    return approval as DshApprovalService;
+  }
+  return undefined;
+}
+export function createLeaseApprovalHandler(getApproval: () => DshApprovalService | undefined): HostHandler {
+  // 作用：生成 host.approval.request_lease 宿主方法——把 Python 的 Lease 签发请求转成 DSH ctx.approval 请求；
+  // 仅 allowed-once 放行并回 {"decision":"allowed-once"}，其余任何结果或异常都失败（→ Python 侧 LEASE_REJECTED）
+  return async (params: any) => {
+    const req = parseLeaseApprovalRequest(params);
+    const approval = getApproval();
+    if (!approval) throw new Error("LEASE_REJECTED: ctx.approval unavailable");
+    const reason = `Capsule ${req.capsuleId} requests ${req.action} on ${req.provider} ${req.resource} for ${req.ttlSeconds}s`;
+    const result = await approval.request({ toolName: req.toolName, reason });
+    const decision = typeof result === "string" ? result : (result as any)?.decision;
+    if (decision !== "allowed-once") throw new Error(`LEASE_REJECTED: decision=${String(decision)}`);
+    return { decision: "allowed-once" };
+  };
+}
+function parseLeaseApprovalRequest(params: any): LeaseApprovalRequest {
+  // 作用：参数校验（Fail Closed）——必填字段缺失或类型非法直接抛错，绝不"尽量执行"
+  if (typeof params !== "object" || params === null) throw new Error("LEASE_REJECTED: invalid params");
+  const { capsuleId, provider, resource, action, ttlSeconds } = params;
+  for (const [key, value] of Object.entries({ capsuleId, provider, resource, action })) {
+    if (typeof value !== "string" || value.length === 0) throw new Error(`LEASE_REJECTED: invalid param ${key}`);
+  }
+  if (!Number.isInteger(ttlSeconds) || (ttlSeconds as number) <= 0) throw new Error("LEASE_REJECTED: invalid param ttlSeconds");
+  const toolName = params["toolName"];
+  if (toolName !== undefined && typeof toolName !== "string") throw new Error("LEASE_REJECTED: invalid param toolName");
+  return { capsuleId, provider, resource, action, ttlSeconds, toolName };
 }

--- a/adapter/src/credentials.test.ts
+++ b/adapter/src/credentials.test.ts
@@ -1,0 +1,42 @@
+import { describe, expect, it } from "vitest";
+import { createCredentialResolveHandler, getCredentialService, type DshCredentialService } from "./credentials.js";
+const SECRET = "ghp_super_secret_value";
+function credentialsReturning(result: unknown): DshCredentialService {
+  // 作用：构造返回固定结果的假 DSH credentials 服务
+  return { resolve: async (_ref: string) => result };
+}
+describe("createCredentialResolveHandler", () => {
+  it("字符串结果包装为 {value} 返回", async () => {
+    await expect(createCredentialResolveHandler(() => credentialsReturning(SECRET))({ ref: "GITHUB_TOKEN" })).resolves.toEqual({ value: SECRET });
+  });
+  it("对象形 {value} 结果同样支持（规则 15：以实际 DSH 返回形状为准）", async () => {
+    await expect(createCredentialResolveHandler(() => credentialsReturning({ value: SECRET }))({ ref: "GITHUB_TOKEN" })).resolves.toEqual({ value: SECRET });
+  });
+  it("凭据服务不可用即抛 CREDENTIAL_NOT_CONFIGURED（Fail Closed）", async () => {
+    await expect(createCredentialResolveHandler(() => undefined)({ ref: "GITHUB_TOKEN" })).rejects.toThrow("CREDENTIAL_NOT_CONFIGURED");
+  });
+  it("空值/缺失值/非字符串值均拒绝且错误信息不含 Secret", async () => {
+    for (const result of ["", undefined, null, 123, {}]) {
+      const err = await createCredentialResolveHandler(() => credentialsReturning(result))({ ref: "GITHUB_TOKEN" }).catch((e: Error) => e);
+      expect(err).toBeInstanceOf(Error);
+      expect(err.message).toContain("CREDENTIAL_NOT_CONFIGURED");
+      expect(err.message).not.toContain(SECRET);
+    }
+  });
+  it("ref 缺失或非法即拒绝", async () => {
+    const handler = createCredentialResolveHandler(() => credentialsReturning(SECRET));
+    await expect(handler({})).rejects.toThrow("CREDENTIAL_NOT_CONFIGURED");
+    await expect(handler({ ref: "" })).rejects.toThrow("CREDENTIAL_NOT_CONFIGURED");
+    await expect(handler(null)).rejects.toThrow("CREDENTIAL_NOT_CONFIGURED");
+  });
+});
+describe("getCredentialService", () => {
+  it("从 ctx 定位 credentials 服务", () => {
+    expect(getCredentialService({ credentials: { resolve: async () => SECRET } })).toBeDefined();
+  });
+  it("形状不符或缺失时返回 undefined（Fail Closed）", () => {
+    expect(getCredentialService({})).toBeUndefined();
+    expect(getCredentialService({ credentials: {} })).toBeUndefined();
+    expect(getCredentialService({ credentials: 42 })).toBeUndefined();
+  });
+});

--- a/adapter/src/credentials.ts
+++ b/adapter/src/credentials.ts
@@ -1,5 +1,36 @@
-// TODO(Phase 4): 集成 DSH ctx.credentials，在可信侧解析真实凭据，禁止进入容器与日志
-export async function resolveCredential(_ref: string): Promise<string> {
-  // 作用：预留的凭据解析入口（Phase 4 实现；每次 operation 重新 resolve，不跨 operation 缓存）
-  throw new Error("not implemented until Phase 4");
+import type { HostHandler } from "./rpc-client.js";
+// 作用：DSH Credentials 集成（规格第 23/33 节）——真实 Secret 只在可信侧解析后经 RPC 返回 Python Runtime，
+// 禁止打印、记录或写入任何持久化介质；Python 侧每次 operation 重新 resolve，不跨 operation 缓存。
+export interface DshCredentialService {
+  // TODO(Phase 4, 规则 15)：DSH ctx.credentials 的确切形状以当前安装版本官方 TypeScript 类型定义与官方文档为准，
+  // 本接口仅按技术规格第 33 节声明 resolve(ref)；接入真实 DSH 时需核对其返回值结构。
+  resolve(ref: string): Promise<unknown>;
+}
+export function getCredentialService(ctx: Record<string, unknown>): DshCredentialService | undefined {
+  // 作用：从 DSH ctx 上定位 credentials 服务；形状不符（无 resolve 方法）即视为不可用（Fail Closed）
+  const credentials = ctx["credentials"];
+  if (typeof credentials === "object" && credentials !== null && typeof (credentials as any).resolve === "function") {
+    return credentials as DshCredentialService;
+  }
+  return undefined;
+}
+export function createCredentialResolveHandler(getCredentials: () => DshCredentialService | undefined): HostHandler {
+  // 作用：生成 host.credential.resolve 宿主方法——在可信侧调用 ctx.credentials 解析真实凭据并仅回传 {"value"}；
+  // 任何失败路径的错误信息只包含 ref 名，绝不包含 Secret 值
+  return async (params: any) => {
+    const ref = parseCredentialRef(params);
+    const credentials = getCredentials();
+    if (!credentials) throw new Error("CREDENTIAL_NOT_CONFIGURED: ctx.credentials unavailable");
+    const resolved = await credentials.resolve(ref);
+    const value = typeof resolved === "string" ? resolved : typeof resolved === "object" && resolved !== null ? (resolved as any)["value"] : undefined;
+    if (typeof value !== "string" || value.length === 0) throw new Error(`CREDENTIAL_NOT_CONFIGURED: cannot resolve ${ref}`);
+    return { value };
+  };
+}
+function parseCredentialRef(params: any): string {
+  // 作用：参数校验（Fail Closed）——ref 必须是非空字符串
+  if (typeof params !== "object" || params === null || typeof params["ref"] !== "string" || params["ref"].length === 0) {
+    throw new Error("CREDENTIAL_NOT_CONFIGURED: invalid params");
+  }
+  return params["ref"];
 }

--- a/adapter/src/index.ts
+++ b/adapter/src/index.ts
@@ -1,19 +1,21 @@
 import { PythonRuntime } from "./rpc-client.js";
+import { createLeaseApprovalHandler, getApprovalService } from "./approval.js";
+import { createCredentialResolveHandler, getCredentialService } from "./credentials.js";
 export type CapsuleHostContext = Record<string, unknown>;
 export type DisposeHook = () => void | Promise<void>;
 export { PythonRuntime };
-// 作用：DSH 插件入口——Phase 0 只做"spawn Python Runtime + ping 健康检查"；
-// ctx.tools.register / ctx.approval / ctx.credentials 的具体属性名待 Phase 1+ 以当前安装版本
-// 的官方 TypeScript 类型定义核对后再接入，禁止凭猜测硬编码。
+// 作用：DSH 插件入口——spawn Python Runtime + ping 健康检查 + 注册宿主反向调用方法（host.approval.request_lease /
+// host.credential.resolve，规格第 33 节）；ctx.tools.register 的具体属性名待以当前安装版本官方 TypeScript 类型核对后再接入
+// （规则 15，禁止凭猜测硬编码）。
 export async function apply(ctx: CapsuleHostContext): Promise<DisposeHook> {
   const runtime = new PythonRuntime();
+  runtime.registerHostMethod("host.approval.request_lease", createLeaseApprovalHandler(() => getApprovalService(ctx)));
+  runtime.registerHostMethod("host.credential.resolve", createCredentialResolveHandler(() => getCredentialService(ctx)));
   await runtime.start();
   const disposeHooks: DisposeHook[] = [];
   const registerDispose = (hook: DisposeHook) => disposeHooks.push(hook);
-  void ctx;
   void registerDispose;
   // TODO(Phase 1): 读取 capsule.list_tools 并调用 ctx.tools.register 注册 Capsule Tools
-  // TODO(Phase 4): registerHostMethod("host.approval.request_lease", ...) 与 host.credential.resolve
   return async () => {
     for (const hook of disposeHooks) {
       await hook();

--- a/runtime/dsh_capsule/broker/__init__.py
+++ b/runtime/dsh_capsule/broker/__init__.py
@@ -1,0 +1,2 @@
+from dsh_capsule.broker.credentials import CredentialResolver
+__all__ = ["CredentialResolver"]

--- a/runtime/dsh_capsule/broker/credentials.py
+++ b/runtime/dsh_capsule/broker/credentials.py
@@ -1,0 +1,17 @@
+import asyncio
+from dsh_capsule.rpc import RpcConnection, RpcError
+class CredentialResolver:
+    def __init__(self, conn: RpcConnection):
+        # 作用：封装 Python→TS 反向凭据解析通道 host.credential.resolve（规格第 23/33 节）——真实 Secret 仅短暂存在于可信侧内存
+        self._conn = conn
+    async def resolve(self, ref: str) -> str:
+        # 作用：单次 operation 解析凭据——每次调用都重新发起反向 RPC（per-operation resolve，不跨 operation 缓存、不写 SQLite/日志）；
+        # 任何失败统一抛 CREDENTIAL_NOT_CONFIGURED 且异常信息绝不携带 Secret 值（Fail Closed）
+        try:
+            result = await self._conn.call("host.credential.resolve", {"ref": ref})
+        except (RpcError, asyncio.TimeoutError) as exc:
+            raise RuntimeError(f"CREDENTIAL_NOT_CONFIGURED: resolve failed for {ref}") from exc
+        value = result.get("value") if isinstance(result, dict) else None
+        if not isinstance(value, str) or not value:
+            raise RuntimeError(f"CREDENTIAL_NOT_CONFIGURED: empty value for {ref}")
+        return value

--- a/runtime/dsh_capsule/lease/__init__.py
+++ b/runtime/dsh_capsule/lease/__init__.py
@@ -1,3 +1,5 @@
+from dsh_capsule.lease.approval import ApprovalClient
+from dsh_capsule.lease.gateway import LeaseGateway
 from dsh_capsule.lease.models import CapabilityLease, LeaseError
 from dsh_capsule.lease.service import LeaseService
-__all__ = ["CapabilityLease", "LeaseError", "LeaseService"]
+__all__ = ["ApprovalClient", "CapabilityLease", "LeaseError", "LeaseGateway", "LeaseService"]

--- a/runtime/dsh_capsule/lease/approval.py
+++ b/runtime/dsh_capsule/lease/approval.py
@@ -1,0 +1,21 @@
+import asyncio
+from dsh_capsule.lease.models import LeaseError
+from dsh_capsule.rpc import RpcConnection, RpcError
+APPROVAL_TIMEOUT_SECONDS = 300.0
+ALLOWED_DECISION = "allowed-once"
+class ApprovalClient:
+    def __init__(self, conn: RpcConnection):
+        # 作用：封装 Python→TS 反向授权通道 host.approval.request_lease（规格第 33 节）——DSH one-shot Approval 批准的是"签发一张明确 Scope、明确 TTL 的 Lease"，而非逐请求批准
+        self._conn = conn
+    async def request_lease(self, *, capsule_id: str, provider: str, resource: str, action: str, ttl_seconds: int, tool_name: str | None = None) -> None:
+        # 作用：向宿主请求 Lease 签发授权；仅 decision == allowed-once 放行，其余结果或通道异常一律抛 LEASE_REJECTED（Fail Closed）；授权参数不含任何 Secret
+        params: dict = {"capsuleId": capsule_id, "provider": provider, "resource": resource, "action": action, "ttlSeconds": ttl_seconds}
+        if tool_name is not None:
+            params["toolName"] = tool_name
+        try:
+            result = await self._conn.call("host.approval.request_lease", params, timeout=APPROVAL_TIMEOUT_SECONDS)
+        except (RpcError, asyncio.TimeoutError) as exc:
+            raise LeaseError("LEASE_REJECTED", f"approval channel failed: {exc}") from exc
+        decision = result.get("decision") if isinstance(result, dict) else None
+        if decision != ALLOWED_DECISION:
+            raise LeaseError("LEASE_REJECTED", f"approval decision: {decision!r}")

--- a/runtime/dsh_capsule/lease/gateway.py
+++ b/runtime/dsh_capsule/lease/gateway.py
@@ -1,0 +1,20 @@
+from dsh_capsule.lease.approval import ApprovalClient
+from dsh_capsule.lease.models import CapabilityLease, LeaseError
+from dsh_capsule.lease.service import LeaseService
+DEFAULT_TTL_SECONDS = 600
+MAX_TTL_SECONDS = 1800
+class LeaseGateway:
+    def __init__(self, service: LeaseService, approval: ApprovalClient):
+        # 作用：Lease 签发编排层（规格第 18/19 节）——先查可复用 ACTIVE Lease，未命中才走宿主 one-shot Approval 授权后签发
+        self._service = service
+        self._approval = approval
+    async def request(self, *, capsule_id: str, capsule_instance_id: str, session_id: str, provider: str, resource: str, action: str, ttl_seconds: int = DEFAULT_TTL_SECONDS, tool_name: str | None = None) -> CapabilityLease:
+        # 作用：完整签发链路：同实例+会话+Provider+资源且已含该 action 的未过期 Lease 直接复用（不再弹 Approval）；
+        # 未命中或不含该 action 时经宿主 Approval 授权后签发新 Lease；TTL 非法（<=0 或超上限）一律拒绝（Fail Closed）
+        if ttl_seconds <= 0 or ttl_seconds > MAX_TTL_SECONDS:
+            raise LeaseError("LEASE_REJECTED", f"invalid ttl_seconds: {ttl_seconds}")
+        lease = await self._service.find_matching_lease(capsule_instance_id=capsule_instance_id, session_id=session_id, provider=provider, resource=resource)
+        if lease is not None and action in lease.actions:
+            return lease
+        await self._approval.request_lease(capsule_id=capsule_id, provider=provider, resource=resource, action=action, ttl_seconds=ttl_seconds, tool_name=tool_name)
+        return await self._service.issue(capsule_id=capsule_id, capsule_instance_id=capsule_instance_id, session_id=session_id, provider=provider, resource=resource, actions={action}, ttl_seconds=ttl_seconds)

--- a/runtime/dsh_capsule/main.py
+++ b/runtime/dsh_capsule/main.py
@@ -3,24 +3,51 @@ import os
 import sys
 from pathlib import Path
 from dsh_capsule.capsule.manager import CapsuleManager
-from dsh_capsule.rpc import RpcConnection
+from dsh_capsule.lease.approval import ApprovalClient
+from dsh_capsule.lease.gateway import LeaseGateway, DEFAULT_TTL_SECONDS
+from dsh_capsule.lease.service import LeaseService
+from dsh_capsule.rpc import RpcConnection, RpcError
+from dsh_capsule.storage.db import LeaseStore
 DEFAULT_CAPSULES_DIR = Path(__file__).resolve().parents[2] / "capsules"
-def build_connection(manager: CapsuleManager) -> RpcConnection:
-    # 作用：组装 RPC 连接并注册 system.* 与 capsule.* 方法
-    conn = RpcConnection(sys.stdin.buffer, sys.stdout.buffer)
+DEFAULT_LEASES_DB = "leases.db"
+def register_methods(conn: RpcConnection, manager: CapsuleManager, gateway: LeaseGateway) -> None:
+    # 作用：注册全部 TS→Python 方法（system.* / capsule.* / lease.*）；stdout 严格保留给 NDJSON RPC
     conn.register("system.ping", lambda params: {"pong": True})
     conn.register("system.call_host", lambda params: conn.call(params["method"], params.get("params") or {}))
     conn.register("capsule.list_tools", lambda params: manager.list_tools())
     conn.register("capsule.invoke", lambda params: manager.invoke(params["tool"], params.get("args") or {}, params.get("timeout")))
-    return conn
+    conn.register("lease.request", lambda params: handle_lease_request(gateway, params))
+async def handle_lease_request(gateway: LeaseGateway, params: dict) -> dict:
+    # 作用：lease.request 入口（规格第 18 节签发链路）——参数显式校验（缺失/类型非法即 JSON-RPC invalid params）；
+    # 返回值只含 Lease 公开字段，不含任何 Secret；LeaseError 由 RPC 层转为带 data.code 的错误响应
+    for key in ("capsuleId", "capsuleInstanceId", "sessionId", "provider", "resource", "action"):
+        if not isinstance(params.get(key), str) or not params[key]:
+            raise RpcError(-32602, f"invalid param: {key}")
+    ttl = params.get("ttlSeconds", DEFAULT_TTL_SECONDS)
+    if not isinstance(ttl, int) or isinstance(ttl, bool):
+        raise RpcError(-32602, "invalid param: ttlSeconds")
+    tool_name = params.get("toolName")
+    if tool_name is not None and not isinstance(tool_name, str):
+        raise RpcError(-32602, "invalid param: toolName")
+    lease = await gateway.request(
+        capsule_id=params["capsuleId"], capsule_instance_id=params["capsuleInstanceId"], session_id=params["sessionId"],
+        provider=params["provider"], resource=params["resource"], action=params["action"],
+        ttl_seconds=ttl, tool_name=tool_name,
+    )
+    return {"leaseId": lease.id, "capsuleId": lease.capsule_id, "provider": lease.provider, "resource": lease.resource, "actions": sorted(lease.actions), "status": lease.status, "expiresAt": lease.expires_at}
 async def amain() -> None:
-    # 作用：异步入口，持续处理 RPC 消息直到 stdin 关闭（EOF）；退出前回收全部 Capsule 实例
+    # 作用：异步入口——组装 CapsuleManager / LeaseStore / LeaseGateway（含反向 Approval 通道）并运行 RPC 主循环直到 stdin EOF；退出前回收容器与存储
     manager = CapsuleManager(os.environ.get("DSH_CAPSULE_DIR") or DEFAULT_CAPSULES_DIR)
-    conn = build_connection(manager)
+    store = LeaseStore(os.environ.get("DSH_CAPSULE_LEASES_DB") or DEFAULT_LEASES_DB)
+    await store.connect()
+    conn = RpcConnection(sys.stdin.buffer, sys.stdout.buffer)
+    gateway = LeaseGateway(LeaseService(store), ApprovalClient(conn))
+    register_methods(conn, manager, gateway)
     try:
         await conn.run()
     finally:
         await manager.shutdown()
+        await store.close()
 def main() -> None:
     # 作用：同步入口；stdout 严格保留给 NDJSON RPC，运行日志一律写 stderr
     print("[dsh-capsule] runtime starting", file=sys.stderr)

--- a/runtime/dsh_capsule/rpc.py
+++ b/runtime/dsh_capsule/rpc.py
@@ -63,8 +63,13 @@ class RpcConnection:
                 if msg_id is not None:
                     await self._send({"jsonrpc": "2.0", "id": msg_id, "error": {"code": exc.code, "message": str(exc)}})
             except Exception as exc:
+                # 作用：业务异常统一转 RPC error；携带 str 型 code（如 LeaseError 的 LEASE_REJECTED）时附加到 error.data.code 供对端结构化取用
                 if msg_id is not None:
-                    await self._send({"jsonrpc": "2.0", "id": msg_id, "error": {"code": -32603, "message": str(exc)}})
+                    error: dict = {"code": -32603, "message": str(exc)}
+                    code = getattr(exc, "code", None)
+                    if isinstance(code, str):
+                        error["data"] = {"code": code}
+                    await self._send({"jsonrpc": "2.0", "id": msg_id, "error": error})
             else:
                 if msg_id is not None:
                     await self._send({"jsonrpc": "2.0", "id": msg_id, "result": result})

--- a/tests/integration/test_main_lease.py
+++ b/tests/integration/test_main_lease.py
@@ -1,0 +1,73 @@
+import json
+import os
+import subprocess
+import sys
+RUNTIME_DIR = os.path.join(os.path.dirname(os.path.abspath(__file__)), "..", "..", "runtime")
+LEASE_PARAMS = {
+    "capsuleId": "github-reader", "capsuleInstanceId": "inst-1", "sessionId": "S100",
+    "provider": "github", "resource": "repo:foo/bar", "action": "issues.read", "ttlSeconds": 600,
+}
+def _spawn(tmp_path) -> subprocess.Popen:
+    # 作用：以真实子进程启动 Runtime，Lease 数据库指向临时目录避免污染仓库
+    env = {**os.environ, "DSH_CAPSULE_LEASES_DB": str(tmp_path / "leases.db")}
+    return subprocess.Popen(
+        [sys.executable, "-m", "dsh_capsule.main"],
+        cwd=RUNTIME_DIR, stdin=subprocess.PIPE, stdout=subprocess.PIPE, stderr=subprocess.PIPE,
+        text=True, bufsize=1, env=env,
+    )
+def _send(proc: subprocess.Popen, msg: dict) -> None:
+    # 作用：向 Runtime stdin 写入一行 NDJSON 请求
+    proc.stdin.write(json.dumps(msg) + "\n")
+    proc.stdin.flush()
+def _read(proc: subprocess.Popen) -> dict:
+    # 作用：从 Runtime stdout 读取一行 NDJSON 消息
+    return json.loads(proc.stdout.readline())
+def _request_lease(proc: subprocess.Popen, msg_id: str, approval_decision: str | None) -> dict:
+    # 作用：发起一次 lease.request 并扮演宿主响应反向 Approval；approval_decision 为 None 表示不应触发 Approval
+    _send(proc, {"jsonrpc": "2.0", "id": msg_id, "method": "lease.request", "params": LEASE_PARAMS})
+    if approval_decision is not None:
+        approval = _read(proc)
+        assert approval["method"] == "host.approval.request_lease"
+        assert approval["params"]["capsuleId"] == "github-reader"
+        assert approval["params"]["resource"] == "repo:foo/bar"
+        _send(proc, {"jsonrpc": "2.0", "id": approval["id"], "result": {"decision": approval_decision}})
+    return _read(proc)
+def test_lease_request_full_approval_loop(tmp_path):
+    # 作用：完整签发链路（规格第 18/33 节）：首次请求触发反向 host.approval.request_lease → 宿主回 allowed-once →
+    # 签发 ACTIVE Lease 返回；第二次同参数请求直接复用，不再触发 Approval（规格第 19 节）
+    proc = _spawn(tmp_path)
+    try:
+        first = _request_lease(proc, "ts-1", approval_decision="allowed-once")
+        assert first["id"] == "ts-1"
+        assert first["result"]["status"] == "ACTIVE"
+        assert first["result"]["actions"] == ["issues.read"]
+        assert first["result"]["resource"] == "repo:foo/bar"
+        second = _request_lease(proc, "ts-2", approval_decision=None)
+        assert second["id"] == "ts-2"
+        assert second["result"]["leaseId"] == first["result"]["leaseId"]
+    finally:
+        proc.stdin.close()
+        proc.wait(timeout=10)
+def test_lease_request_rejected_returns_structured_error(tmp_path):
+    # 作用：宿主拒绝时 lease.request 返回 RPC error，error.data.code 为统一错误码 LEASE_REJECTED（规格第 28 节）
+    proc = _spawn(tmp_path)
+    try:
+        resp = _request_lease(proc, "ts-1", approval_decision="rejected")
+        assert resp["id"] == "ts-1"
+        assert resp["error"]["data"]["code"] == "LEASE_REJECTED"
+    finally:
+        proc.stdin.close()
+        proc.wait(timeout=10)
+def test_lease_request_invalid_params(tmp_path):
+    # 作用：参数缺失/类型非法返回 JSON-RPC invalid params（-32602），不发起授权（Fail Closed）
+    proc = _spawn(tmp_path)
+    try:
+        _send(proc, {"jsonrpc": "2.0", "id": "ts-1", "method": "lease.request", "params": {"capsuleId": "github-reader"}})
+        resp = _read(proc)
+        assert resp["error"]["code"] == -32602
+        _send(proc, {"jsonrpc": "2.0", "id": "ts-2", "method": "lease.request", "params": {**LEASE_PARAMS, "ttlSeconds": "600"}})
+        resp = _read(proc)
+        assert resp["error"]["code"] == -32602
+    finally:
+        proc.stdin.close()
+        proc.wait(timeout=10)

--- a/tests/unit/test_approval_client.py
+++ b/tests/unit/test_approval_client.py
@@ -1,0 +1,59 @@
+import asyncio
+import pytest
+from dsh_capsule.lease.approval import ApprovalClient
+from dsh_capsule.lease.models import LeaseError
+from dsh_capsule.rpc import RpcError
+class FakeConn:
+    def __init__(self, result=None, error: str | None = None, timeout: bool = False):
+        # 作用：模拟反向 RPC 通道，记录调用供断言；可注入错误/超时
+        self.calls: list[tuple[str, dict, float]] = []
+        self._result = result
+        self._error = error
+        self._timeout = timeout
+    async def call(self, method: str, params: dict | None = None, timeout: float = 30.0):
+        # 作用：记录一次反向调用并按注入行为返回或抛错
+        self.calls.append((method, params or {}, timeout))
+        if self._timeout:
+            raise asyncio.TimeoutError()
+        if self._error is not None:
+            raise RpcError(-32000, self._error)
+        return self._result
+BASE = {"capsule_id": "github-reader", "provider": "github", "resource": "repo:foo/bar", "action": "issues.read", "ttl_seconds": 600}
+def _request(client: ApprovalClient, **overrides) -> None:
+    asyncio.run(client.request_lease(**{**BASE, **overrides}))
+def test_allowed_once_passes_and_sends_params():
+    # 作用：宿主返回 allowed-once 即放行；验证反向调用方法名与参数（camelCase，不含任何 Secret）
+    conn = FakeConn(result={"decision": "allowed-once"})
+    _request(ApprovalClient(conn))
+    assert conn.calls[0][0] == "host.approval.request_lease"
+    assert conn.calls[0][1] == {"capsuleId": "github-reader", "provider": "github", "resource": "repo:foo/bar", "action": "issues.read", "ttlSeconds": 600}
+def test_tool_name_optional():
+    # 作用：toolName 非必填；传入时透传给宿主
+    conn = FakeConn(result={"decision": "allowed-once"})
+    _request(ApprovalClient(conn), tool_name="github_get_issue")
+    assert conn.calls[0][1]["toolName"] == "github_get_issue"
+def test_rejected_decision_denied():
+    # 作用：宿主返回 rejected 即抛 LEASE_REJECTED（Fail Closed）
+    conn = FakeConn(result={"decision": "rejected"})
+    with pytest.raises(LeaseError, match="LEASE_REJECTED"):
+        _request(ApprovalClient(conn))
+def test_missing_decision_denied():
+    # 作用：宿主结果缺 decision 字段即抛 LEASE_REJECTED（Fail Closed，不"尽量执行"）
+    conn = FakeConn(result={})
+    with pytest.raises(LeaseError, match="LEASE_REJECTED"):
+        _request(ApprovalClient(conn))
+def test_non_dict_result_denied():
+    # 作用：宿主返回非对象结果（如裸字符串）即抛 LEASE_REJECTED
+    conn = FakeConn(result="allowed-once")
+    with pytest.raises(LeaseError, match="LEASE_REJECTED"):
+        _request(ApprovalClient(conn))
+def test_rpc_error_denied():
+    # 作用：反向 RPC 失败（如宿主抛错）即抛 LEASE_REJECTED（Fail Closed）
+    conn = FakeConn(error="host boom")
+    with pytest.raises(LeaseError, match="LEASE_REJECTED"):
+        _request(ApprovalClient(conn))
+def test_timeout_denied():
+    # 作用：授权通道超时即抛 LEASE_REJECTED（Fail Closed）
+    conn = FakeConn(timeout=True)
+    with pytest.raises(LeaseError, match="LEASE_REJECTED"):
+        _request(ApprovalClient(conn))

--- a/tests/unit/test_credential_resolver.py
+++ b/tests/unit/test_credential_resolver.py
@@ -1,0 +1,55 @@
+import asyncio
+import pytest
+from dsh_capsule.broker.credentials import CredentialResolver
+from dsh_capsule.rpc import RpcError
+SECRET = "ghp_super_secret_value"
+class FakeConn:
+    def __init__(self, result=None, error: str | None = None, error_with_secret: str | None = None):
+        # 作用：模拟反向 RPC 通道，记录调用供断言；可注入错误或"错误消息疑似含 Secret"的极端场景
+        self.calls: list[tuple[str, dict]] = []
+        self._result = result
+        self._error = error
+        self._error_with_secret = error_with_secret
+    async def call(self, method: str, params: dict | None = None, timeout: float = 30.0):
+        # 作用：记录一次反向调用并按注入行为返回或抛错
+        self.calls.append((method, params or {}))
+        if self._error_with_secret is not None:
+            raise RpcError(-32000, self._error_with_secret)
+        if self._error is not None:
+            raise RpcError(-32000, self._error)
+        return self._result
+def test_resolve_returns_value():
+    # 作用：宿主返回 {"value": ...} 即取出并返回；验证反向调用方法名与 ref 参数
+    conn = FakeConn(result={"value": SECRET})
+    value = asyncio.run(CredentialResolver(conn).resolve("GITHUB_TOKEN"))
+    assert value == SECRET
+    assert conn.calls[0][0] == "host.credential.resolve"
+    assert conn.calls[0][1] == {"ref": "GITHUB_TOKEN"}
+def test_resolve_not_cached_across_operations():
+    # 作用：per-operation resolve——连续两次调用必发起两次反向 RPC，绝不跨 operation 缓存（规格第 23 节）
+    conn = FakeConn(result={"value": SECRET})
+    resolver = CredentialResolver(conn)
+    assert asyncio.run(resolver.resolve("GITHUB_TOKEN")) == SECRET
+    assert asyncio.run(resolver.resolve("GITHUB_TOKEN")) == SECRET
+    assert len(conn.calls) == 2
+def test_missing_value_denied():
+    # 作用：宿主结果缺 value 字段即抛 CREDENTIAL_NOT_CONFIGURED（Fail Closed）
+    conn = FakeConn(result={})
+    with pytest.raises(RuntimeError, match="CREDENTIAL_NOT_CONFIGURED"):
+        asyncio.run(CredentialResolver(conn).resolve("GITHUB_TOKEN"))
+def test_empty_value_denied():
+    # 作用：空字符串凭据视为未配置（Fail Closed）
+    conn = FakeConn(result={"value": ""})
+    with pytest.raises(RuntimeError, match="CREDENTIAL_NOT_CONFIGURED"):
+        asyncio.run(CredentialResolver(conn).resolve("GITHUB_TOKEN"))
+def test_non_dict_result_denied():
+    # 作用：宿主返回非对象结果（如裸字符串 Secret）不透传解析，直接抛 CREDENTIAL_NOT_CONFIGURED
+    conn = FakeConn(result=SECRET)
+    with pytest.raises(RuntimeError, match="CREDENTIAL_NOT_CONFIGURED"):
+        asyncio.run(CredentialResolver(conn).resolve("GITHUB_TOKEN"))
+def test_rpc_error_denied_without_leaking_secret():
+    # 作用：反向 RPC 失败统一抛 CREDENTIAL_NOT_CONFIGURED；即使宿主错误消息疑似含 Secret，异常信息也绝不携带（规格第 23 节）
+    conn = FakeConn(error_with_secret=f"resolve failed for {SECRET}")
+    with pytest.raises(RuntimeError, match="CREDENTIAL_NOT_CONFIGURED") as exc_info:
+        asyncio.run(CredentialResolver(conn).resolve("GITHUB_TOKEN"))
+    assert SECRET not in str(exc_info.value)

--- a/tests/unit/test_lease_gateway.py
+++ b/tests/unit/test_lease_gateway.py
@@ -1,0 +1,75 @@
+import asyncio
+import pytest
+from dsh_capsule.lease.approval import ApprovalClient
+from dsh_capsule.lease.gateway import LeaseGateway
+from dsh_capsule.lease.models import LeaseError
+from dsh_capsule.lease.service import LeaseService
+from dsh_capsule.storage.db import LeaseStore
+class FakeConn:
+    def __init__(self, result=None, error: str | None = None):
+        # 作用：模拟反向 RPC 授权通道，记录调用次数供"是否再次弹 Approval"断言
+        self.calls: list[tuple[str, dict]] = []
+        self._result = result
+        self._error = error
+    async def call(self, method: str, params: dict | None = None, timeout: float = 30.0):
+        # 作用：记录一次授权请求并按注入行为返回或抛错
+        self.calls.append((method, params or {}))
+        if self._error is not None:
+            raise LeaseError("LEASE_REJECTED", self._error)
+        return self._result
+@pytest.fixture
+def gateway_parts(tmp_path):
+    # 作用：每个用例独立的真实 LeaseService（临时 SQLite）+ FakeConn 授权通道，返回可组合三元组
+    store = LeaseStore(str(tmp_path / "leases.db"))
+    asyncio.run(store.connect())
+    yield store
+    asyncio.run(store.close())
+def _make_gateway(store: LeaseStore, approval_result=None, approval_error=None) -> tuple[LeaseGateway, FakeConn]:
+    # 作用：组装"真实 LeaseService + 可控 Fake 授权通道"的 LeaseGateway
+    conn = FakeConn(result=approval_result, error=approval_error)
+    return LeaseGateway(LeaseService(store), ApprovalClient(conn)), conn
+BASE = {"capsule_id": "github-reader", "capsule_instance_id": "inst-1", "session_id": "S100", "provider": "github", "resource": "repo:foo/bar", "action": "issues.read"}
+def test_first_request_issues_lease_after_approval(gateway_parts):
+    # 作用：首次请求无 Lease——先走宿主 one-shot 授权（allowed-once），再签发 ACTIVE Lease（规格第 18 节）
+    gateway, conn = _make_gateway(gateway_parts, approval_result={"decision": "allowed-once"})
+    lease = asyncio.run(gateway.request(**BASE))
+    assert lease.status == "ACTIVE"
+    assert lease.actions == {"issues.read"}
+    assert len(conn.calls) == 1
+    assert conn.calls[0][0] == "host.approval.request_lease"
+def test_reuse_skips_approval(gateway_parts):
+    # 作用：同实例+会话+Provider+资源+action 的第二次请求直接复用 Lease，不再弹 Approval（规格第 19 节）
+    gateway, conn = _make_gateway(gateway_parts, approval_result={"decision": "allowed-once"})
+    first = asyncio.run(gateway.request(**BASE))
+    second = asyncio.run(gateway.request(**BASE))
+    assert len(conn.calls) == 1
+    assert second.id == first.id
+def test_rejected_approval_issues_nothing(gateway_parts):
+    # 作用：宿主拒绝（rejected）即抛 LEASE_REJECTED 且绝不签发 Lease（Fail Closed）
+    gateway, conn = _make_gateway(gateway_parts, approval_result={"decision": "rejected"})
+    with pytest.raises(LeaseError, match="LEASE_REJECTED"):
+        asyncio.run(gateway.request(**BASE))
+    assert asyncio.run(gateway_parts.list_all()) == []
+def test_new_action_requires_new_approval(gateway_parts):
+    # 作用：已有 Lease 不含请求的 action 时必须重新授权签发新 Lease（复用条件包含 action，规格第 19 节）
+    gateway, conn = _make_gateway(gateway_parts, approval_result={"decision": "allowed-once"})
+    first = asyncio.run(gateway.request(**BASE))
+    second = asyncio.run(gateway.request(**{**BASE, "action": "issues.write"}))
+    assert len(conn.calls) == 2
+    assert second.id != first.id
+    assert "issues.write" in second.actions
+def test_cross_session_no_reuse(gateway_parts):
+    # 作用：Session B 请求同资源不走 Session A 的复用路径，必须重新授权（不能跨 Session 复用）
+    gateway, conn = _make_gateway(gateway_parts, approval_result={"decision": "allowed-once"})
+    asyncio.run(gateway.request(**BASE))
+    lease_b = asyncio.run(gateway.request(**{**BASE, "session_id": "S200"}))
+    assert len(conn.calls) == 2
+    assert lease_b.session_id == "S200"
+def test_invalid_ttl_rejected_without_approval(gateway_parts):
+    # 作用：TTL 非法（<=0 或超上限 1800）在发起授权前即抛 LEASE_REJECTED（Fail Closed）
+    gateway, conn = _make_gateway(gateway_parts, approval_result={"decision": "allowed-once"})
+    with pytest.raises(LeaseError, match="LEASE_REJECTED"):
+        asyncio.run(gateway.request(**{**BASE, "ttl_seconds": 0}))
+    with pytest.raises(LeaseError, match="LEASE_REJECTED"):
+        asyncio.run(gateway.request(**{**BASE, "ttl_seconds": 9999}))
+    assert conn.calls == []


### PR DESCRIPTION
- Python 反向通道：host.approval.request_lease（仅 allowed-once 放行，Fail Closed） 与 host.credential.resolve（per-operation 不缓存，Secret 不入日志/异常）
- LeaseGateway 签发编排：复用检查→one-shot 授权→签发；TTL 非法授权前拒绝
- main.py 组装 LeaseStore/LeaseGateway 并注册 lease.request 入口（参数校验 -32602）
- rpc.py：业务异常附加 error.data.code 结构化错误码
- TS 侧实装 approval.ts/credentials.ts 并注册 host 方法（ctx 属性名按官方类型防御检查）
- 新增 22 个测试：单测+子进程集成双向链路，全量 55 passed