### PR TITLE
feat(phase-5): GitHub Reader——BrokerServer + GitHub Provider + issues…

### DIFF
--- a/capsules/github-reader/Dockerfile
+++ b/capsules/github-reader/Dockerfile
@@ -1,0 +1,7 @@
+FROM python:3.11-slim
+COPY sdk/python /sdk
+RUN pip install --no-cache-dir /sdk
+COPY capsules/github-reader/app.py /app/app.py
+USER 65534:65534
+WORKDIR /app
+CMD ["python", "/app/app.py"]

--- a/capsules/github-reader/app.py
+++ b/capsules/github-reader/app.py
@@ -1,0 +1,15 @@
+import re
+from dsh_capsule_sdk import CapsuleApp
+app = CapsuleApp()
+REPO_PATTERN = re.compile(r"^[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+$")
+@app.tool("github_get_issue")
+async def github_get_issue(args: dict, ctx) -> dict:
+    # 作用：读取单个 GitHub Issue（规格第 26 节）——校验 repo 格式后经宿主 Broker 转发，Token 永不进入容器
+    repo = args.get("repo")
+    issue_number = args.get("issue_number")
+    if not isinstance(repo, str) or not REPO_PATTERN.match(repo):
+        raise RuntimeError("CAPSULE_PROTOCOL_ERROR: repo must be owner/repo")
+    if not isinstance(issue_number, int) or issue_number < 1:
+        raise RuntimeError("CAPSULE_PROTOCOL_ERROR: issue_number must be a positive integer")
+    return await ctx.broker.call(provider="github", action="issues.read", resource=f"repo:{repo}", payload={"repo": repo, "issue_number": issue_number})
+app.run()

--- a/capsules/github-reader/capsule.yaml
+++ b/capsules/github-reader/capsule.yaml
@@ -1,0 +1,38 @@
+apiVersion: dsh-capsule/v1
+kind: Capsule
+metadata:
+  id: github-reader
+  version: 0.1.0
+  description: Read GitHub issues through the DSH credential broker.
+runtime:
+  image: dsh-capsule/github-reader:0.1.0
+  command:
+    - python
+    - /app/app.py
+resources:
+  memory_mb: 256
+  cpus: 0.5
+  pids: 64
+credentials:
+  - provider: github
+    credential_ref: GITHUB_TOKEN
+    allowed_actions:
+      - issues.read
+    default_ttl_seconds: 600
+    max_ttl_seconds: 1800
+tools:
+  - name: github_get_issue
+    description: Read one GitHub issue from a repository.
+    parameters:
+      type: object
+      additionalProperties: false
+      required:
+        - repo
+        - issue_number
+      properties:
+        repo:
+          type: string
+          description: owner/repo
+        issue_number:
+          type: integer
+          minimum: 1

--- a/capsules/malicious-demo/app.py
+++ b/capsules/malicious-demo/app.py
@@ -63,5 +63,9 @@ async def attack_dead_loop(args: dict, ctx) -> dict:
 async def attack_crash(args: dict, ctx) -> dict:
     # 作用：进程自杀——验证容器崩溃被隔离且实例可自动重建
     os._exit(137)
+@app.tool("try_unauthorized_broker_action")
+async def try_unauthorized_broker_action(args: dict, ctx) -> dict:
+    # 作用：请求 manifest 未声明的越权 action（repo.delete）——宿主 BrokerPolicy 必须 CAPABILITY_DENIED（规格第 27 节）
+    return await ctx.broker.call(provider="github", action="repo.delete", resource="repo:foo/bar", payload={})
 if __name__ == "__main__":
     app.run()

--- a/capsules/malicious-demo/capsule.yaml
+++ b/capsules/malicious-demo/capsule.yaml
@@ -71,3 +71,9 @@ tools:
       type: object
       additionalProperties: false
       properties: {}
+  - name: try_unauthorized_broker_action
+    description: Request an action not declared by the manifest to test broker capability denial.
+    parameters:
+      type: object
+      additionalProperties: false
+      properties: {}

--- a/runtime/dsh_capsule/broker/__init__.py
+++ b/runtime/dsh_capsule/broker/__init__.py
@@ -1,2 +1,7 @@
 from dsh_capsule.broker.credentials import CredentialResolver
-__all__ = ["CredentialResolver"]
+from dsh_capsule.broker.errors import BrokerError
+from dsh_capsule.broker.github import GitHubProvider
+from dsh_capsule.broker.policy import BrokerPolicy
+from dsh_capsule.broker.providers import ProviderAdapter, ProviderRegistry
+from dsh_capsule.broker.server import BrokerServer
+__all__ = ["BrokerError", "BrokerPolicy", "BrokerServer", "CredentialResolver", "GitHubProvider", "ProviderAdapter", "ProviderRegistry"]

--- a/runtime/dsh_capsule/broker/errors.py
+++ b/runtime/dsh_capsule/broker/errors.py
@@ -1,0 +1,6 @@
+class BrokerError(Exception):
+    # 作用：统一携带规格第 28 节错误码的 Broker 异常；Fail Closed 下任意校验失败即抛出，且消息绝不包含 Secret
+    def __init__(self, code: str, message: str = ""):
+        super().__init__(f"{code}: {message}" if message else code)
+        self.code = code
+        self.message = message

--- a/runtime/dsh_capsule/broker/github.py
+++ b/runtime/dsh_capsule/broker/github.py
@@ -1,0 +1,44 @@
+import httpx
+from dsh_capsule.broker.errors import BrokerError
+GITHUB_API_BASE = "https://api.github.com"
+GITHUB_API_VERSION = "2022-11-28"
+ISSUES_READ = "issues.read"
+class GitHubProvider:
+    # 作用：GitHub Provider（规格第 22 节）——MVP 仅支持只读的 issues.read，映射 GET /repos/{owner}/{repo}/issues/{issue_number}
+    def __init__(self, api_base: str = GITHUB_API_BASE, timeout: float = 15.0, transport: httpx.AsyncBaseTransport | None = None):
+        # 作用：api_base/timeout 可配置；transport 仅供测试注入 MockTransport，生产留空走默认网络栈
+        self.name = "github"
+        self._api_base = api_base.rstrip("/")
+        self._timeout = timeout
+        self._transport = transport
+    async def execute(self, *, credential: str, action: str, resource: str, payload: dict) -> dict:
+        # 作用：执行受控 GitHub 请求——Token 仅用于构造请求头且绝不进入日志/异常；响应只提取白名单字段（规格第 26 节）
+        if action != ISSUES_READ:
+            raise BrokerError("CAPABILITY_DENIED", f"unsupported action: {action}")
+        repo = payload.get("repo")
+        issue_number = payload.get("issue_number")
+        if not isinstance(repo, str) or len(repo.split("/", 1)) != 2 or not all(repo.split("/", 1)):
+            raise BrokerError("BROKER_PROTOCOL_ERROR", "invalid repo (expect owner/repo)")
+        if not isinstance(issue_number, int) or isinstance(issue_number, bool) or issue_number < 1:
+            raise BrokerError("BROKER_PROTOCOL_ERROR", "invalid issue_number")
+        url = f"{self._api_base}/repos/{repo}/issues/{issue_number}"
+        headers = {"Authorization": f"Bearer {credential}", "Accept": "application/vnd.github+json", "X-GitHub-Api-Version": GITHUB_API_VERSION}
+        try:
+            async with httpx.AsyncClient(timeout=self._timeout, transport=self._transport) as client:
+                resp = await client.get(url, headers=headers)
+        except httpx.TimeoutException as exc:
+            raise BrokerError("PROVIDER_TIMEOUT", "github request timed out") from exc
+        except httpx.HTTPError as exc:
+            raise BrokerError("PROVIDER_ERROR", "github request failed") from exc
+        if resp.status_code == 404:
+            raise BrokerError("PROVIDER_ERROR", "github issue not found")
+        if resp.status_code != 200:
+            raise BrokerError("PROVIDER_ERROR", f"github status {resp.status_code}")
+        try:
+            data = resp.json()
+        except ValueError as exc:
+            raise BrokerError("PROVIDER_ERROR", "invalid github response body") from exc
+        return {
+            "number": data.get("number"), "title": data.get("title"), "state": data.get("state"),
+            "author": (data.get("user") or {}).get("login"), "body": data.get("body"), "html_url": data.get("html_url"),
+        }

--- a/runtime/dsh_capsule/broker/policy.py
+++ b/runtime/dsh_capsule/broker/policy.py
@@ -1,0 +1,13 @@
+from dsh_capsule.broker.errors import BrokerError
+from dsh_capsule.capsule.manifest import CapsuleManifest, CredentialRequest
+class BrokerPolicy:
+    @staticmethod
+    def check(manifest: CapsuleManifest, provider: str, action: str) -> CredentialRequest:
+        # 作用：manifest 声明校验（规格第 27 节）——请求的 (provider, action) 必须在 capsule.yaml credentials.allowed_actions 内；
+        # 未声明的越权请求直接 CAPABILITY_DENIED，绝不进入授权/签发流程（Fail Closed）
+        for cred in manifest.credentials:
+            if cred.provider == provider:
+                if action in cred.allowed_actions:
+                    return cred
+                raise BrokerError("CAPABILITY_DENIED", f"action {action} not declared by capsule manifest")
+        raise BrokerError("CAPABILITY_DENIED", f"provider {provider} not declared by capsule manifest")

--- a/runtime/dsh_capsule/broker/providers.py
+++ b/runtime/dsh_capsule/broker/providers.py
@@ -1,0 +1,18 @@
+import typing
+from dsh_capsule.broker.errors import BrokerError
+class ProviderAdapter(typing.Protocol):
+    # 作用：Provider 适配器协议（规格第 22 节）——只允许 Provider+Action Allowlist 式受控执行，禁止通用 HTTP 代理
+    name: str
+    def execute(self, *, credential: str, action: str, resource: str, payload: dict) -> typing.Awaitable[dict]: ...
+class ProviderRegistry:
+    def __init__(self):
+        # 作用：Provider 注册表——名称到适配器的唯一映射
+        self._providers: dict[str, ProviderAdapter] = {}
+    def register(self, provider: ProviderAdapter) -> None:
+        # 作用：注册 Provider；同名重复注册视为配置错误直接抛错（Fail Closed）
+        if provider.name in self._providers:
+            raise BrokerError("BROKER_PROTOCOL_ERROR", f"duplicate provider: {provider.name}")
+        self._providers[provider.name] = provider
+    def get(self, name: str) -> ProviderAdapter | None:
+        # 作用：按名称查找 Provider；未注册返回 None（由调用方按 PROVIDER_NOT_FOUND 处理）
+        return self._providers.get(name)

--- a/runtime/dsh_capsule/broker/server.py
+++ b/runtime/dsh_capsule/broker/server.py
@@ -1,0 +1,111 @@
+import asyncio
+import json
+from dsh_capsule.broker.credentials import CredentialResolver
+from dsh_capsule.broker.errors import BrokerError
+from dsh_capsule.broker.policy import BrokerPolicy
+from dsh_capsule.broker.providers import ProviderRegistry
+from dsh_capsule.capsule.docker_backend import enforce_response_limit
+from dsh_capsule.capsule.instance import CapsuleInstance
+from dsh_capsule.capsule.manifest import CapsuleManifest
+from dsh_capsule.lease.gateway import LeaseGateway
+from dsh_capsule.lease.models import LeaseError
+PROVIDER_TIMEOUT_SECONDS = 15.0
+class BrokerServer:
+    def __init__(self, manifest: CapsuleManifest, instance: CapsuleInstance, gateway: LeaseGateway, resolver: CredentialResolver, providers: ProviderRegistry, provider_timeout: float = PROVIDER_TIMEOUT_SECONDS):
+        # 作用：实例独享 Broker（规格第 22/23/34 节）——监听 broker.sock 接收容器内受控能力请求，
+        # 策略校验后走 Lease 签发→凭据解析→Provider 执行链路；策略不写死在 Socket Handler 内
+        self._manifest = manifest
+        self._instance = instance
+        self._gateway = gateway
+        self._resolver = resolver
+        self._providers = providers
+        self._provider_timeout = provider_timeout
+        self._server: asyncio.AbstractServer | None = None
+        self._session_id: str | None = None
+        self._tool_name: str | None = None
+    @property
+    def broker_sock_path(self) -> str:
+        # 作用：本实例 broker.sock 路径（位于独享 IPC 目录，仅当前实例容器可见）
+        return str(self._instance.ipc_dir / "broker.sock")
+    def begin_call(self, session_id: str | None, tool_name: str | None) -> None:
+        # 作用：由可信 Runtime 在 tool.invoke 期间设置调用上下文——容器不可信，session 身份只能来自宿主侧（规格第 24 节）
+        self._session_id = session_id
+        self._tool_name = tool_name
+    def end_call(self) -> None:
+        # 作用：清除调用上下文，防止跨调用残留（配合 Manager 的同实例串行锁）
+        self._session_id = None
+        self._tool_name = None
+    async def start(self) -> None:
+        # 作用：在独享 IPC 目录监听 broker.sock，等待容器内 SDK 连入
+        self._server = await asyncio.start_unix_server(self._handle_conn, path=self.broker_sock_path)
+    async def stop(self) -> None:
+        # 作用：关闭监听并断开全部连接；IPC 目录由 DockerBackend 统一回收
+        if self._server is not None:
+            self._server.close()
+            await self._server.wait_closed()
+            self._server = None
+    async def _handle_conn(self, reader: asyncio.StreamReader, writer: asyncio.StreamWriter) -> None:
+        # 作用：处理容器连接——逐行读取 NDJSON broker.call 请求并回写响应；全程不打印任何请求内容（Secret 安全）
+        try:
+            while True:
+                line = await reader.readline()
+                if not line:
+                    break
+                try:
+                    msg = json.loads(line)
+                except json.JSONDecodeError as exc:
+                    await self._write(writer, {"jsonrpc": "2.0", "id": None, "error": {"code": -32700, "message": f"parse error: {exc}"}})
+                    continue
+                await self._write(writer, await self._dispatch(msg))
+        finally:
+            writer.close()
+    async def _dispatch(self, msg: dict) -> dict:
+        # 作用：分发单条请求：仅支持 broker.call；BrokerError/LeaseError 统一携带 data.code（规格第 28 节错误码）
+        msg_id = msg.get("id")
+        try:
+            if msg.get("method") != "broker.call":
+                raise BrokerError("BROKER_PROTOCOL_ERROR", f"unsupported method: {msg.get('method')}")
+            result = await self.handle_call(msg.get("params") or {})
+            return {"jsonrpc": "2.0", "id": msg_id, "result": result}
+        except (BrokerError, LeaseError) as exc:
+            return {"jsonrpc": "2.0", "id": msg_id, "error": {"code": -32000, "message": str(exc), "data": {"code": exc.code}}}
+        except Exception as exc:
+            return {"jsonrpc": "2.0", "id": msg_id, "error": {"code": -32000, "message": str(exc), "data": {"code": "BROKER_PROTOCOL_ERROR"}}}
+    async def handle_call(self, params: dict) -> dict:
+        # 作用：单次 Broker 请求核心链路（规格第 23 节）——参数校验→manifest 声明校验→session 校验→
+        # Lease 签发（复用/授权）→Provider 定位→凭据 per-operation resolve→Provider 执行（15s 超时）→响应 2MB 上限；
+        # Secret 不进日志/持久化/结果/异常（Fail Closed）
+        provider = params.get("provider")
+        action = params.get("action")
+        resource = params.get("resource")
+        payload = params.get("payload") or {}
+        if not isinstance(provider, str) or not isinstance(action, str) or not isinstance(resource, str) or not resource:
+            raise BrokerError("BROKER_PROTOCOL_ERROR", "invalid broker.call params")
+        if not isinstance(payload, dict):
+            raise BrokerError("BROKER_PROTOCOL_ERROR", "payload must be an object")
+        cred = BrokerPolicy.check(self._manifest, provider, action)
+        if not self._session_id:
+            raise BrokerError("LEASE_REQUIRED", "session identity required")
+        lease = await self._gateway.request(
+            capsule_id=self._manifest.metadata.id, capsule_instance_id=self._instance.instance_id,
+            session_id=self._session_id, provider=provider, resource=resource, action=action,
+            ttl_seconds=cred.default_ttl_seconds, tool_name=self._tool_name,
+        )
+        adapter = self._providers.get(provider)
+        if adapter is None:
+            raise BrokerError("PROVIDER_NOT_FOUND", f"provider not registered: {provider}")
+        credential = await self._resolver.resolve(cred.credential_ref)
+        try:
+            result = await asyncio.wait_for(adapter.execute(credential=credential, action=action, resource=resource, payload=payload), self._provider_timeout)
+        except asyncio.TimeoutError as exc:
+            raise BrokerError("PROVIDER_TIMEOUT", f"provider timed out after {self._provider_timeout}s") from exc
+        except BrokerError:
+            raise
+        except Exception as exc:
+            raise BrokerError("PROVIDER_ERROR", "provider request failed") from exc
+        enforce_response_limit(json.dumps(result, ensure_ascii=False).encode("utf-8"))
+        return result
+    async def _write(self, writer: asyncio.StreamWriter, msg: dict) -> None:
+        # 作用：序列化单行 NDJSON 响应并刷写
+        writer.write((json.dumps(msg, ensure_ascii=False) + "\n").encode("utf-8"))
+        await writer.drain()

--- a/runtime/dsh_capsule/capsule/docker_backend.py
+++ b/runtime/dsh_capsule/capsule/docker_backend.py
@@ -67,7 +67,7 @@ class DockerBackend:
             tmpfs={"/tmp": "rw,noexec,nosuid,size=64m"},
             volumes={str(instance.ipc_dir): {"bind": "/run/capsule", "mode": "rw"}},
             user="65534:65534",
-            environment={"DSH_CAPSULE_PLUGIN_SOCK": "/run/capsule/plugin.sock"},
+            environment={"DSH_CAPSULE_PLUGIN_SOCK": "/run/capsule/plugin.sock", "DSH_CAPSULE_BROKER_SOCK": "/run/capsule/broker.sock"},
             working_dir="/app",
         )
     async def _wait_plugin_sock(self, instance: CapsuleInstance) -> None:

--- a/runtime/dsh_capsule/capsule/manager.py
+++ b/runtime/dsh_capsule/capsule/manager.py
@@ -1,16 +1,22 @@
 import asyncio
 import uuid
 from pathlib import Path
+from typing import TYPE_CHECKING, Callable
 from dsh_capsule.capsule.docker_backend import DockerBackend
 from dsh_capsule.capsule.instance import CapsuleInstance
 from dsh_capsule.capsule.manifest import CapsuleManifest, load_manifest
+if TYPE_CHECKING:
+    from dsh_capsule.broker.server import BrokerServer
 class CapsuleManager:
-    def __init__(self, capsules_dir: Path | str, backend: DockerBackend | None = None):
-        # 作用：Capsule 生命周期管理——manifest 发现/校验、实例启动/复用、工具调用分发
+    def __init__(self, capsules_dir: Path | str, backend: DockerBackend | None = None, broker_factory: Callable[[CapsuleManifest, CapsuleInstance], "BrokerServer"] | None = None):
+        # 作用：Capsule 生命周期管理——manifest 发现/校验、实例启动/复用、工具调用分发与 per-instance Broker 挂载
         self._backend = backend or DockerBackend()
+        self._broker_factory = broker_factory
         self._manifests: dict[str, CapsuleManifest] = {}
         self._tool_owners: dict[str, CapsuleManifest] = {}
         self._instances: dict[str, CapsuleInstance] = {}
+        self._broker_servers: dict[str, "BrokerServer"] = {}
+        self._invoke_locks: dict[str, asyncio.Lock] = {}
         self._invoke_seq = 0
         self._discover(Path(capsules_dir))
     def _discover(self, capsules_dir: Path) -> None:
@@ -31,33 +37,54 @@ class CapsuleManager:
             for manifest in self._manifests.values()
             for tool in manifest.tools
         ]
-    async def invoke(self, tool_name: str, args: dict, timeout: float | None = None) -> dict:
-        # 作用：执行一次工具调用——定位所属 Capsule、确保实例健康、经 UDS 下发 tool.invoke；
-        # 超时/协议错误/容器崩溃一律销毁实例（下次调用强制重建），防止病态实例继续服务（Fail Closed）
+    async def invoke(self, tool_name: str, args: dict, timeout: float | None = None, session_id: str | None = None) -> dict:
+        # 作用：执行一次工具调用——定位所属 Capsule、确保实例健康、设置 Broker 调用上下文（session/tool）后经 UDS 下发 tool.invoke；
+        # 同实例调用串行化保证 Broker 上下文可信；超时/协议错误/容器崩溃一律销毁实例（下次调用强制重建），防止病态实例继续服务（Fail Closed）
         manifest = self._tool_owners.get(tool_name)
         if manifest is None:
             raise RuntimeError(f"CAPSULE_NOT_FOUND: unknown tool: {tool_name}")
+        capsule_id = manifest.metadata.id
         instance = await self._ensure_instance(manifest)
+        server = self._broker_servers.get(capsule_id)
+        lock = self._invoke_locks.setdefault(capsule_id, asyncio.Lock())
         self._invoke_seq += 1
         request = {"jsonrpc": "2.0", "id": f"capsule-{self._invoke_seq}", "method": "tool.invoke", "params": {"name": tool_name, "args": args or {}}}
-        try:
-            return await self._backend.invoke(instance, request, timeout)
-        except RuntimeError:
-            await self._backend.stop(instance)
-            self._instances.pop(manifest.metadata.id, None)
-            raise
+        async with lock:
+            if server is not None:
+                server.begin_call(session_id, tool_name)
+            try:
+                return await self._backend.invoke(instance, request, timeout)
+            except RuntimeError:
+                await self._teardown_instance(capsule_id)
+                raise
+            finally:
+                if server is not None:
+                    server.end_call()
     async def _ensure_instance(self, manifest: CapsuleManifest) -> CapsuleInstance:
-        # 作用：获取或启动指定 Capsule 的实例；已存在但不健康则重建
-        instance = self._instances.get(manifest.metadata.id)
+        # 作用：获取或启动指定 Capsule 的实例并挂载其专属 BrokerServer；已存在但不健康则重建
+        capsule_id = manifest.metadata.id
+        instance = self._instances.get(capsule_id)
         if instance is not None and await self._backend.health(instance):
             return instance
         if instance is not None:
-            await self._backend.stop(instance)
+            await self._teardown_instance(capsule_id)
         instance = await self._backend.start(manifest)
-        self._instances[manifest.metadata.id] = instance
+        self._instances[capsule_id] = instance
+        if self._broker_factory is not None:
+            server = self._broker_factory(manifest, instance)
+            await server.start()
+            self._broker_servers[capsule_id] = server
         return instance
-    async def shutdown(self) -> None:
-        # 作用：Runtime 退出时回收全部容器与 IPC 目录
-        for instance in self._instances.values():
+    async def _teardown_instance(self, capsule_id: str) -> None:
+        # 作用：回收实例的 BrokerServer 与容器及独享 IPC 目录
+        server = self._broker_servers.pop(capsule_id, None)
+        if server is not None:
+            await server.stop()
+        instance = self._instances.pop(capsule_id, None)
+        if instance is not None:
             await self._backend.stop(instance)
-        self._instances.clear()
+    async def shutdown(self) -> None:
+        # 作用：Runtime 退出时回收全部 BrokerServer 与容器及 IPC 目录
+        for capsule_id in list(self._instances):
+            await self._teardown_instance(capsule_id)
+        self._invoke_locks.clear()

--- a/runtime/dsh_capsule/main.py
+++ b/runtime/dsh_capsule/main.py
@@ -2,6 +2,10 @@ import asyncio
 import os
 import sys
 from pathlib import Path
+from dsh_capsule.broker.credentials import CredentialResolver
+from dsh_capsule.broker.github import GitHubProvider
+from dsh_capsule.broker.providers import ProviderRegistry
+from dsh_capsule.broker.server import BrokerServer
 from dsh_capsule.capsule.manager import CapsuleManager
 from dsh_capsule.lease.approval import ApprovalClient
 from dsh_capsule.lease.gateway import LeaseGateway, DEFAULT_TTL_SECONDS
@@ -15,7 +19,7 @@ def register_methods(conn: RpcConnection, manager: CapsuleManager, gateway: Leas
     conn.register("system.ping", lambda params: {"pong": True})
     conn.register("system.call_host", lambda params: conn.call(params["method"], params.get("params") or {}))
     conn.register("capsule.list_tools", lambda params: manager.list_tools())
-    conn.register("capsule.invoke", lambda params: manager.invoke(params["tool"], params.get("args") or {}, params.get("timeout")))
+    conn.register("capsule.invoke", lambda params: manager.invoke(params["tool"], params.get("args") or {}, params.get("timeout"), params.get("sessionId")))
     conn.register("lease.request", lambda params: handle_lease_request(gateway, params))
 async def handle_lease_request(gateway: LeaseGateway, params: dict) -> dict:
     # 作用：lease.request 入口（规格第 18 节签发链路）——参数显式校验（缺失/类型非法即 JSON-RPC invalid params）；
@@ -36,12 +40,19 @@ async def handle_lease_request(gateway: LeaseGateway, params: dict) -> dict:
     )
     return {"leaseId": lease.id, "capsuleId": lease.capsule_id, "provider": lease.provider, "resource": lease.resource, "actions": sorted(lease.actions), "status": lease.status, "expiresAt": lease.expires_at}
 async def amain() -> None:
-    # 作用：异步入口——组装 CapsuleManager / LeaseStore / LeaseGateway（含反向 Approval 通道）并运行 RPC 主循环直到 stdin EOF；退出前回收容器与存储
-    manager = CapsuleManager(os.environ.get("DSH_CAPSULE_DIR") or DEFAULT_CAPSULES_DIR)
+    # 作用：异步入口——组装 CapsuleManager（含 per-instance Broker：Lease 授权链路+凭据通道+Provider 注册表）并运行
+    # RPC 主循环直到 stdin EOF；退出前回收容器与存储
     store = LeaseStore(os.environ.get("DSH_CAPSULE_LEASES_DB") or DEFAULT_LEASES_DB)
     await store.connect()
     conn = RpcConnection(sys.stdin.buffer, sys.stdout.buffer)
     gateway = LeaseGateway(LeaseService(store), ApprovalClient(conn))
+    resolver = CredentialResolver(conn)
+    providers = ProviderRegistry()
+    providers.register(GitHubProvider())
+    manager = CapsuleManager(
+        os.environ.get("DSH_CAPSULE_DIR") or DEFAULT_CAPSULES_DIR,
+        broker_factory=lambda manifest, instance: BrokerServer(manifest, instance, gateway, resolver, providers),
+    )
     register_methods(conn, manager, gateway)
     try:
         await conn.run()

--- a/sdk/python/dsh_capsule_sdk/broker.py
+++ b/sdk/python/dsh_capsule_sdk/broker.py
@@ -1,7 +1,31 @@
+import asyncio
+import json
+import os
+BROKER_CALL_TIMEOUT_SECONDS = 360.0
 class BrokerClient:
     def __init__(self, broker_sock: str | None = None):
-        # 作用：占位的 Broker 客户端，Phase 3 实现 UDS broker.sock 受控访问入口
-        self._sock = broker_sock or "/run/capsule/broker.sock"
+        # 作用：容器内经独享 broker.sock 访问宿主 Broker 的受控客户端——Secret 永不出宿主，本客户端只见处理结果
+        self._sock = broker_sock or os.environ.get("DSH_CAPSULE_BROKER_SOCK", "/run/capsule/broker.sock")
     async def call(self, provider: str, action: str, resource: str, payload: dict) -> dict:
-        # 作用：预留的受控能力访问入口（Phase 3 实现，当前 Fail Closed）
-        raise RuntimeError("broker not available until Phase 3")
+        # 作用：向宿主 Broker 发起单次 broker.call 请求并等待响应；超时须覆盖宿主侧人工 Approval 时长；
+        # 错误统一抛 RuntimeError 并优先携带宿主统一错误码（如 CAPABILITY_DENIED / LEASE_REJECTED）
+        reader, writer = await asyncio.open_unix_connection(self._sock)
+        try:
+            request = {"jsonrpc": "2.0", "id": "sdk-1", "method": "broker.call", "params": {"provider": provider, "action": action, "resource": resource, "payload": payload or {}}}
+            writer.write((json.dumps(request, ensure_ascii=False) + "\n").encode("utf-8"))
+            await writer.drain()
+            line = await asyncio.wait_for(reader.readline(), BROKER_CALL_TIMEOUT_SECONDS)
+        finally:
+            writer.close()
+            await writer.wait_closed()
+        if not line:
+            raise RuntimeError("BROKER_PROTOCOL_ERROR: empty response from broker")
+        try:
+            msg = json.loads(line)
+        except json.JSONDecodeError as exc:
+            raise RuntimeError(f"BROKER_PROTOCOL_ERROR: {exc}") from None
+        if "error" in msg:
+            error = msg["error"]
+            code = (error.get("data") or {}).get("code") or error.get("message", "BROKER_PROTOCOL_ERROR")
+            raise RuntimeError(str(code))
+        return msg.get("result")

--- a/tests/integration/test_broker_uds.py
+++ b/tests/integration/test_broker_uds.py
@@ -1,0 +1,113 @@
+import asyncio
+import socket
+import sys
+from pathlib import Path
+import pytest
+REPO_ROOT = Path(__file__).resolve().parents[2]
+sys.path.insert(0, str(REPO_ROOT / "sdk" / "python"))
+from dsh_capsule.broker.providers import ProviderRegistry
+from dsh_capsule.broker.server import BrokerServer
+from dsh_capsule.capsule.instance import CapsuleInstance
+from dsh_capsule.capsule.manifest import CapsuleManifest, CredentialRequest, ManifestMetadata, RuntimeSpec
+from dsh_capsule.lease.models import CapabilityLease
+from dsh_capsule_sdk.broker import BrokerClient
+requires_af_unix = pytest.mark.skipif(not hasattr(socket, "AF_UNIX"), reason="requires AF_UNIX (Linux/WSL2)")
+def _manifest() -> CapsuleManifest:
+    # 作用：声明 github/issues.read 的合法 manifest
+    return CapsuleManifest(
+        apiVersion="dsh-capsule/v1", kind="Capsule",
+        metadata=ManifestMetadata(id="github-reader", version="0.1.0"),
+        runtime=RuntimeSpec(image="img:0.1", command=["python", "/app/app.py"]),
+        credentials=[CredentialRequest(provider="github", credential_ref="GITHUB_TOKEN", allowed_actions=["issues.read"], default_ttl_seconds=600, max_ttl_seconds=1800)],
+    )
+def _lease() -> CapabilityLease:
+    # 作用：已签发的 ACTIVE Lease 桩数据
+    return CapabilityLease(id="L1", capsule_id="github-reader", capsule_instance_id="inst-1", session_id="S100", provider="github", resource="repo:foo/bar", actions={"issues.read"}, issued_at=1.0, expires_at=99999.0)
+class StubGateway:
+    def __init__(self, lease: CapabilityLease | None = None):
+        # 作用：记录签发请求的 LeaseGateway 桩
+        self.calls: list[dict] = []
+        self._lease = lease
+    async def request(self, **kwargs):
+        # 作用：记录参数并返回桩 Lease
+        self.calls.append(kwargs)
+        return self._lease
+class StubResolver:
+    def __init__(self, value: str = "ghp_token"):
+        # 作用：固定返回值的凭据桩
+        self.refs: list[str] = []
+        self._value = value
+    async def resolve(self, ref: str) -> str:
+        # 作用：记录 ref 并返回固定值
+        self.refs.append(ref)
+        return self._value
+class StubProvider:
+    def __init__(self, name: str = "github", result: dict | None = None):
+        # 作用：记录 execute 参数的 Provider 桩
+        self.name = name
+        self.execs: list[dict] = []
+        self._result = result or {"number": 10}
+    async def execute(self, *, credential: str, action: str, resource: str, payload: dict) -> dict:
+        # 作用：记录参数并返回结果
+        self.execs.append({"credential": credential, "action": action, "resource": resource, "payload": payload})
+        return self._result
+async def _make_server(tmp_path) -> tuple[BrokerServer, StubGateway, StubProvider]:
+    # 作用：在临时 IPC 目录启动真实 BrokerServer（监听 broker.sock）并返回桩组件
+    instance = CapsuleInstance(capsule_id="github-reader", instance_id="inst-1")
+    instance.ipc_dir = tmp_path
+    gateway = StubGateway(lease=_lease())
+    provider = StubProvider()
+    providers = ProviderRegistry()
+    providers.register(provider)
+    server = BrokerServer(_manifest(), instance, gateway, StubResolver(), providers)
+    await server.start()
+    return server, gateway, provider
+@requires_af_unix
+def test_sdk_client_full_round_trip(tmp_path):
+    # 作用：真实 UDS 回环（规格第 25/33 节）——SDK BrokerClient 经 broker.sock 调用 BrokerServer，
+    # 全链路（manifest 校验→Lease→凭据→Provider）返回结果；session 上下文由宿主设置
+    async def scenario() -> None:
+        server, gateway, provider = await _make_server(tmp_path)
+        try:
+            server.begin_call("S100", "github_get_issue")
+            result = await BrokerClient(str(tmp_path / "broker.sock")).call(provider="github", action="issues.read", resource="repo:foo/bar", payload={"repo": "foo/bar", "issue_number": 10})
+            assert result == {"number": 10}
+            assert gateway.calls[0]["session_id"] == "S100"
+            assert provider.execs[0]["credential"] == "ghp_token"
+        finally:
+            server.end_call()
+            await server.stop()
+    asyncio.run(scenario())
+@requires_af_unix
+def test_sdk_client_receives_unified_error_code(tmp_path):
+    # 作用：越权 action 经 UDS 回传统一错误码 CAPABILITY_DENIED（规格第 27/28 节）
+    async def scenario() -> None:
+        server, gateway, _ = await _make_server(tmp_path)
+        try:
+            server.begin_call("S100", "github_get_issue")
+            client = BrokerClient(str(tmp_path / "broker.sock"))
+            try:
+                await client.call(provider="github", action="repo.delete", resource="repo:foo/bar", payload={})
+                raise AssertionError("expected CAPABILITY_DENIED")
+            except RuntimeError as exc:
+                assert "CAPABILITY_DENIED" in str(exc)
+            assert gateway.calls == []
+        finally:
+            server.end_call()
+            await server.stop()
+    asyncio.run(scenario())
+@requires_af_unix
+def test_sdk_client_denied_without_session(tmp_path):
+    # 作用：宿主未设置 session 上下文（begin_call 未调用）即 LEASE_REQUIRED（Fail Closed）
+    async def scenario() -> None:
+        server, _, _ = await _make_server(tmp_path)
+        try:
+            client = BrokerClient(str(tmp_path / "broker.sock"))
+            try:
+                await client.call(provider="github", action="issues.read", resource="repo:foo/bar", payload={"repo": "foo/bar", "issue_number": 1})
+                raise AssertionError("expected LEASE_REQUIRED")
+            except RuntimeError as exc:
+                assert "LEASE_REQUIRED" in str(exc)
+        finally:
+            await server.stop()
+    asyncio.run(scenario())

--- a/tests/unit/test_broker_policy.py
+++ b/tests/unit/test_broker_policy.py
@@ -1,0 +1,47 @@
+import pytest
+from dsh_capsule.broker.errors import BrokerError
+from dsh_capsule.broker.policy import BrokerPolicy
+from dsh_capsule.broker.providers import ProviderRegistry
+from dsh_capsule.capsule.manifest import CapsuleManifest, CredentialRequest, ManifestMetadata, RuntimeSpec, ToolSpec
+def _manifest(credentials: list[CredentialRequest]) -> CapsuleManifest:
+    # 作用：构造带 credentials 声明的最小合法 manifest
+    return CapsuleManifest(
+        apiVersion="dsh-capsule/v1", kind="Capsule",
+        metadata=ManifestMetadata(id="github-reader", version="0.1.0"),
+        runtime=RuntimeSpec(image="img:0.1", command=["python", "/app/app.py"]),
+        credentials=credentials,
+        tools=[ToolSpec(name="github_get_issue")],
+    )
+def test_declared_action_passes():
+    # 作用：manifest 已声明的 (provider, action) 通过并返回对应 CredentialRequest（含 credential_ref 与 TTL）
+    manifest = _manifest([CredentialRequest(provider="github", credential_ref="GITHUB_TOKEN", allowed_actions=["issues.read"], default_ttl_seconds=600, max_ttl_seconds=1800)])
+    cred = BrokerPolicy.check(manifest, "github", "issues.read")
+    assert cred.credential_ref == "GITHUB_TOKEN"
+    assert cred.default_ttl_seconds == 600
+def test_undeclared_action_denied():
+    # 作用：provider 已声明但 action 未声明（越权 repo.delete）即 CAPABILITY_DENIED（规格第 27 节）
+    manifest = _manifest([CredentialRequest(provider="github", credential_ref="GITHUB_TOKEN", allowed_actions=["issues.read"])])
+    with pytest.raises(BrokerError, match="CAPABILITY_DENIED"):
+        BrokerPolicy.check(manifest, "github", "repo.delete")
+def test_undeclared_provider_denied():
+    # 作用：manifest 未声明的 provider 即 CAPABILITY_DENIED
+    manifest = _manifest([CredentialRequest(provider="github", credential_ref="GITHUB_TOKEN", allowed_actions=["issues.read"])])
+    with pytest.raises(BrokerError, match="CAPABILITY_DENIED"):
+        BrokerPolicy.check(manifest, "dropbox", "files.read")
+def test_provider_registry_register_and_get():
+    # 作用：注册表按名称查找；未注册返回 None（由调用方按 PROVIDER_NOT_FOUND 处理）
+    registry = ProviderRegistry()
+    class FakeProvider:
+        name = "github"
+    provider = FakeProvider()
+    registry.register(provider)
+    assert registry.get("github") is provider
+    assert registry.get("dropbox") is None
+def test_provider_registry_duplicate_denied():
+    # 作用：同名重复注册即 BROKER_PROTOCOL_ERROR（Fail Closed）
+    registry = ProviderRegistry()
+    class FakeProvider:
+        name = "github"
+    registry.register(FakeProvider())
+    with pytest.raises(BrokerError, match="BROKER_PROTOCOL_ERROR"):
+        registry.register(FakeProvider())

--- a/tests/unit/test_broker_server.py
+++ b/tests/unit/test_broker_server.py
@@ -1,0 +1,177 @@
+import asyncio
+import json
+import pytest
+from dsh_capsule.broker.errors import BrokerError
+from dsh_capsule.broker.providers import ProviderRegistry
+from dsh_capsule.broker.server import BrokerServer
+from dsh_capsule.capsule.instance import CapsuleInstance
+from dsh_capsule.capsule.manifest import CapsuleManifest, CredentialRequest, ManifestMetadata, RuntimeSpec
+from dsh_capsule.lease.models import CapabilityLease, LeaseError
+TOKEN = "ghp_super_secret_value"
+def _manifest() -> CapsuleManifest:
+    # 作用：声明 github/issues.read 的合法 manifest（credential_ref=GITHUB_TOKEN，默认 TTL 600）
+    return CapsuleManifest(
+        apiVersion="dsh-capsule/v1", kind="Capsule",
+        metadata=ManifestMetadata(id="github-reader", version="0.1.0"),
+        runtime=RuntimeSpec(image="img:0.1", command=["python", "/app/app.py"]),
+        credentials=[CredentialRequest(provider="github", credential_ref="GITHUB_TOKEN", allowed_actions=["issues.read"], default_ttl_seconds=600, max_ttl_seconds=1800)],
+    )
+def _lease() -> CapabilityLease:
+    # 作用：构造一个已签发的 ACTIVE Lease 桩数据
+    return CapabilityLease(id="L1", capsule_id="github-reader", capsule_instance_id="inst-1", session_id="S100", provider="github", resource="repo:foo/bar", actions={"issues.read"}, issued_at=1.0, expires_at=99999.0)
+class StubGateway:
+    def __init__(self, lease: CapabilityLease | None = None, error: Exception | None = None):
+        # 作用：记录签发请求的 LeaseGateway 桩；可注入已签发 Lease 或异常（如 LeaseError）
+        self.calls: list[dict] = []
+        self._lease = lease
+        self._error = error
+    async def request(self, **kwargs):
+        # 作用：记录一次完整签发参数并按注入行为返回或抛错
+        self.calls.append(kwargs)
+        if self._error is not None:
+            raise self._error
+        return self._lease
+class StubResolver:
+    def __init__(self, value: str = TOKEN, error: Exception | None = None):
+        # 作用：记录 resolve 调用的凭据桩；可注入异常（如 CREDENTIAL_NOT_CONFIGURED）
+        self.refs: list[str] = []
+        self._value = value
+        self._error = error
+    async def resolve(self, ref: str) -> str:
+        # 作用：记录 ref 并按注入行为返回或抛错
+        self.refs.append(ref)
+        if self._error is not None:
+            raise self._error
+        return self._value
+class StubProvider:
+    name = "github"
+    def __init__(self, result: dict | None = None, error: Exception | None = None, delay: float = 0.0):
+        # 作用：记录 execute 参数的 Provider 桩；可注入结果/异常/延迟（测超时）
+        self.execs: list[dict] = []
+        self._result = result
+        self._error = error
+        self._delay = delay
+    async def execute(self, *, credential: str, action: str, resource: str, payload: dict) -> dict:
+        # 作用：记录一次受控执行并按注入行为返回/抛错/延迟
+        self.execs.append({"credential": credential, "action": action, "resource": resource, "payload": payload})
+        if self._delay:
+            await asyncio.sleep(self._delay)
+        if self._error is not None:
+            raise self._error
+        return self._result
+def _server(gateway, resolver, provider=None, provider_timeout=15.0, instance_id="inst-1") -> BrokerServer:
+    # 作用：组装被测 BrokerServer（真实 manifest + 桩网关/解析器/注册表）
+    providers = ProviderRegistry()
+    if provider is not None:
+        providers.register(provider)
+    return BrokerServer(_manifest(), CapsuleInstance(capsule_id="github-reader", instance_id=instance_id), gateway, resolver, providers, provider_timeout=provider_timeout)
+CALL_PARAMS = {"provider": "github", "action": "issues.read", "resource": "repo:foo/bar", "payload": {"repo": "foo/bar", "issue_number": 10}}
+def _call(server: BrokerServer, params: dict | None = None, session_id: str | None = "S100") -> dict:
+    # 作用：设置调用上下文后执行一次 handle_call（session 身份来自宿主侧，容器不可提供）
+    server.begin_call(session_id, "github_get_issue")
+    try:
+        return asyncio.run(server.handle_call(params or CALL_PARAMS))
+    finally:
+        server.end_call()
+def test_happy_path_full_chain():
+    # 作用：完整链路（规格第 23 节）——manifest 校验→Lease 签发（TTL 取 manifest 声明）→凭据 resolve→Provider 执行→结果返回
+    gateway = StubGateway(lease=_lease())
+    resolver = StubResolver()
+    provider = StubProvider(result={"number": 10, "title": "T"})
+    result = _call(_server(gateway, resolver, provider))
+    assert result == {"number": 10, "title": "T"}
+    assert gateway.calls[0]["session_id"] == "S100"
+    assert gateway.calls[0]["capsule_instance_id"] == "inst-1"
+    assert gateway.calls[0]["ttl_seconds"] == 600
+    assert gateway.calls[0]["tool_name"] == "github_get_issue"
+    assert resolver.refs == ["GITHUB_TOKEN"]
+    assert provider.execs[0]["credential"] == TOKEN
+def test_unauthorized_action_denied_before_approval():
+    # 作用：manifest 未声明的越权 action（repo.delete）即 CAPABILITY_DENIED，且绝不进入授权流程（gateway 无调用，规格第 27 节）
+    gateway = StubGateway(lease=_lease())
+    server = _server(gateway, StubResolver(), StubProvider())
+    with pytest.raises(BrokerError, match="CAPABILITY_DENIED"):
+        _call(server, {**CALL_PARAMS, "action": "repo.delete"})
+    assert gateway.calls == []
+def test_missing_session_identity_denied():
+    # 作用：宿主侧无 session 身份（无法确定 Session）即 LEASE_REQUIRED（Fail Closed，规格第 29 节）
+    gateway = StubGateway(lease=_lease())
+    server = _server(gateway, StubResolver(), StubProvider())
+    with pytest.raises(BrokerError, match="LEASE_REQUIRED"):
+        _call(server, session_id=None)
+    assert gateway.calls == []
+def test_approval_rejection_propagates():
+    # 作用：宿主授权被拒（LEASE_REJECTED）原样透传给容器，不再 resolve 凭据、不执行 Provider
+    gateway = StubGateway(error=LeaseError("LEASE_REJECTED", "user denied"))
+    resolver = StubResolver()
+    provider = StubProvider()
+    with pytest.raises(LeaseError, match="LEASE_REJECTED"):
+        _call(_server(gateway, resolver, provider))
+    assert resolver.refs == []
+    assert provider.execs == []
+def test_provider_not_registered():
+    # 作用：Provider 未注册即 PROVIDER_NOT_FOUND（发生在 Lease 签发之后，规格第 23 节流程顺序）
+    gateway = StubGateway(lease=_lease())
+    with pytest.raises(BrokerError, match="PROVIDER_NOT_FOUND"):
+        _call(_server(gateway, StubResolver(), provider=None))
+    assert len(gateway.calls) == 1
+def test_credential_failure_denied():
+    # 作用：凭据 resolve 失败即 CREDENTIAL_NOT_CONFIGURED 透传，不执行 Provider
+    gateway = StubGateway(lease=_lease())
+    resolver = StubResolver(error=RuntimeError("CREDENTIAL_NOT_CONFIGURED: empty value for GITHUB_TOKEN"))
+    provider = StubProvider()
+    with pytest.raises(RuntimeError, match="CREDENTIAL_NOT_CONFIGURED"):
+        _call(_server(gateway, resolver, provider))
+    assert provider.execs == []
+def test_provider_broker_error_propagates():
+    # 作用：Provider 抛 BrokerError（如 PROVIDER_ERROR）时错误码原样透传
+    gateway = StubGateway(lease=_lease())
+    provider = StubProvider(error=BrokerError("PROVIDER_ERROR", "github status 403"))
+    with pytest.raises(BrokerError, match="PROVIDER_ERROR"):
+        _call(_server(gateway, StubResolver(), provider))
+def test_provider_crash_maps_provider_error():
+    # 作用：Provider 崩溃（普通异常）统一映射 PROVIDER_ERROR，不泄露内部细节
+    gateway = StubGateway(lease=_lease())
+    provider = StubProvider(error=ValueError("boom with internal detail"))
+    with pytest.raises(BrokerError, match="PROVIDER_ERROR"):
+        _call(_server(gateway, StubResolver(), provider))
+def test_provider_timeout_denied():
+    # 作用：Provider 执行超过 15s（测试注入 0.05s）即 PROVIDER_TIMEOUT（Fail Closed）
+    gateway = StubGateway(lease=_lease())
+    provider = StubProvider(result={}, delay=0.5)
+    with pytest.raises(BrokerError, match="PROVIDER_TIMEOUT"):
+        _call(_server(gateway, StubResolver(), provider, provider_timeout=0.05))
+def test_oversized_provider_result_denied():
+    # 作用：Provider 结果序列化超 2MB 上限即 CAPSULE_OUTPUT_TOO_LARGE（规格第 6 节响应上限）
+    gateway = StubGateway(lease=_lease())
+    provider = StubProvider(result={"payload": "x" * (3 * 1024 * 1024)})
+    with pytest.raises(RuntimeError, match="CAPSULE_OUTPUT_TOO_LARGE"):
+        _call(_server(gateway, StubResolver(), provider))
+def test_invalid_params_denied():
+    # 作用：broker.call 参数缺失/类型非法即 BROKER_PROTOCOL_ERROR，不触发任何后续链路
+    gateway = StubGateway(lease=_lease())
+    server = _server(gateway, StubResolver(), StubProvider())
+    for bad in ({"provider": "github"}, {"provider": "github", "action": "issues.read", "resource": ""}, {**CALL_PARAMS, "payload": "not-object"}):
+        with pytest.raises(BrokerError, match="BROKER_PROTOCOL_ERROR"):
+            _call(server, bad)
+    assert gateway.calls == []
+def test_dispatch_maps_error_codes():
+    # 作用：_dispatch 把 BrokerError/LeaseError 转为携带 data.code 的 JSON-RPC error；非法 method 即 BROKER_PROTOCOL_ERROR
+    gateway = StubGateway(lease=_lease())
+    server = _server(gateway, StubResolver(), StubProvider())
+    resp = asyncio.run(server._dispatch({"jsonrpc": "2.0", "id": "b-1", "method": "broker.call", "params": {**CALL_PARAMS, "action": "repo.delete"}}))
+    assert resp["id"] == "b-1"
+    assert resp["error"]["data"]["code"] == "CAPABILITY_DENIED"
+    resp2 = asyncio.run(server._dispatch({"jsonrpc": "2.0", "id": "b-2", "method": "other.method", "params": {}}))
+    assert resp2["error"]["data"]["code"] == "BROKER_PROTOCOL_ERROR"
+def test_dispatch_happy_path_returns_result():
+    # 作用：_dispatch 正常路径返回 result 字段
+    gateway = StubGateway(lease=_lease())
+    provider = StubProvider(result={"number": 10})
+    resp = asyncio.run(server_dispatch(gateway, provider))
+    assert resp["result"] == {"number": 10}
+async def server_dispatch(gateway, provider) -> dict:
+    # 作用：异步执行一次 _dispatch 便于同步断言
+    server = _server(gateway, StubResolver(), provider)
+    server.begin_call("S100", "github_get_issue")
+    return await server._dispatch({"jsonrpc": "2.0", "id": "b-1", "method": "broker.call", "params": CALL_PARAMS})

--- a/tests/unit/test_github_provider.py
+++ b/tests/unit/test_github_provider.py
@@ -1,0 +1,67 @@
+import asyncio
+import httpx
+import pytest
+from dsh_capsule.broker.errors import BrokerError
+from dsh_capsule.broker.github import GitHubProvider
+GITHUB_ISSUE = {"number": 10, "title": "T", "state": "open", "user": {"login": "alice"}, "body": "B", "html_url": "https://example.com/10"}
+def _provider(handler) -> GitHubProvider:
+    # 作用：构造注入 MockTransport 的 GitHubProvider（不发真实网络请求）
+    return GitHubProvider(transport=httpx.MockTransport(handler))
+def test_issues_read_maps_whitelist_fields():
+    # 作用：issues.read 正常路径——URL 与 Authorization 头正确，响应只提取白名单字段（规格第 26 节）
+    def handler(request: httpx.Request) -> httpx.Response:
+        assert request.url.path == "/repos/foo/bar/issues/10"
+        assert request.headers["Authorization"] == "Bearer ghp_test"
+        assert request.headers["Accept"] == "application/vnd.github+json"
+        return httpx.Response(200, json=GITHUB_ISSUE)
+    provider = _provider(handler)
+    result = asyncio.run(provider.execute(credential="ghp_test", action="issues.read", resource="repo:foo/bar", payload={"repo": "foo/bar", "issue_number": 10}))
+    assert result == {"number": 10, "title": "T", "state": "open", "author": "alice", "body": "B", "html_url": "https://example.com/10"}
+def test_unsupported_action_denied():
+    # 作用：非 issues.read 的 action（如 repo.delete）即 CAPABILITY_DENIED——只读 Provider，无网络请求发出
+    def handler(request: httpx.Request) -> httpx.Response:
+        raise AssertionError("must not reach network")
+    provider = _provider(handler)
+    with pytest.raises(BrokerError, match="CAPABILITY_DENIED"):
+        asyncio.run(provider.execute(credential="ghp_test", action="repo.delete", resource="repo:foo/bar", payload={"repo": "foo/bar", "issue_number": 1}))
+def test_invalid_repo_payload_denied():
+    # 作用：payload 的 repo 缺 owner/repo 结构即 BROKER_PROTOCOL_ERROR（不信任容器提交的数据）
+    provider = _provider(lambda request: httpx.Response(200, json={}))
+    for bad_repo in ("foobar", "", "/bar", "foo/"):
+        with pytest.raises(BrokerError, match="BROKER_PROTOCOL_ERROR"):
+            asyncio.run(provider.execute(credential="ghp_test", action="issues.read", resource="repo:foo/bar", payload={"repo": bad_repo, "issue_number": 1}))
+def test_invalid_issue_number_denied():
+    # 作用：issue_number 非正整数即 BROKER_PROTOCOL_ERROR
+    provider = _provider(lambda request: httpx.Response(200, json={}))
+    for bad in (0, -1, "10", 1.5, None, True):
+        with pytest.raises(BrokerError, match="BROKER_PROTOCOL_ERROR"):
+            asyncio.run(provider.execute(credential="ghp_test", action="issues.read", resource="repo:foo/bar", payload={"repo": "foo/bar", "issue_number": bad}))
+def test_not_found_maps_provider_error():
+    # 作用：GitHub 404 映射 PROVIDER_ERROR（issue not found），不透传原始响应体
+    provider = _provider(lambda request: httpx.Response(404, json={"message": "Not Found"}))
+    with pytest.raises(BrokerError, match="PROVIDER_ERROR"):
+        asyncio.run(provider.execute(credential="ghp_test", action="issues.read", resource="repo:foo/bar", payload={"repo": "foo/bar", "issue_number": 999}))
+def test_non_200_maps_provider_error():
+    # 作用：非 200/404 状态码（如 403）映射 PROVIDER_ERROR + 状态码，消息不含 Token
+    provider = _provider(lambda request: httpx.Response(403, json={"message": "rate limited"}))
+    with pytest.raises(BrokerError, match="PROVIDER_ERROR: github status 403"):
+        asyncio.run(provider.execute(credential="ghp_test", action="issues.read", resource="repo:foo/bar", payload={"repo": "foo/bar", "issue_number": 1}))
+def test_timeout_maps_provider_timeout():
+    # 作用：httpx 超时异常映射 PROVIDER_TIMEOUT，异常链不含 Secret
+    def handler(request: httpx.Request) -> httpx.Response:
+        raise httpx.ConnectTimeout("timed out")
+    provider = _provider(handler)
+    with pytest.raises(BrokerError, match="PROVIDER_TIMEOUT"):
+        asyncio.run(provider.execute(credential="ghp_test", action="issues.read", resource="repo:foo/bar", payload={"repo": "foo/bar", "issue_number": 1}))
+def test_network_error_maps_provider_error():
+    # 作用：httpx 网络异常映射 PROVIDER_ERROR
+    def handler(request: httpx.Request) -> httpx.Response:
+        raise httpx.ConnectError("dns failure")
+    provider = _provider(handler)
+    with pytest.raises(BrokerError, match="PROVIDER_ERROR"):
+        asyncio.run(provider.execute(credential="ghp_test", action="issues.read", resource="repo:foo/bar", payload={"repo": "foo/bar", "issue_number": 1}))
+def test_invalid_json_body_maps_provider_error():
+    # 作用：响应体非 JSON 映射 PROVIDER_ERROR
+    provider = _provider(lambda request: httpx.Response(200, content=b"not-json", headers={"Content-Type": "application/json"}))
+    with pytest.raises(BrokerError, match="PROVIDER_ERROR"):
+        asyncio.run(provider.execute(credential="ghp_test", action="issues.read", resource="repo:foo/bar", payload={"repo": "foo/bar", "issue_number": 1}))


### PR DESCRIPTION
….read

- Broker 核心链路：manifest 策略校验（越权 action 进授权前即拒）→ Lease 签发 → 凭据 per-operation resolve → Provider 执行（15s 超时）→ 2MB 响应上限
- GitHubProvider：仅 issues.read，只读，响应仅提取白名单字段，Token 不入日志/异常
- Manager 挂载 per-instance broker.sock，session 身份仅由宿主侧串行上下文提供
- SDK BrokerClient 实装（UDS broker.call，错误携带统一错误码）
- 新增 github-reader capsule；malicious-demo 增加越权 Broker 探针
- 新增 27 个测试（全量 82 passed）：Provider/Policy/Server 单测 + UDS 回环集成