### PR TITLE
feat(phase-6): 安全 Demo——Lease 阻断校验与第 37 节 9 项端到端验证

### DIFF
--- a/runtime/dsh_capsule/lease/gateway.py
+++ b/runtime/dsh_capsule/lease/gateway.py
@@ -1,3 +1,4 @@
+import time
 from dsh_capsule.lease.approval import ApprovalClient
 from dsh_capsule.lease.models import CapabilityLease, LeaseError
 from dsh_capsule.lease.service import LeaseService
@@ -5,16 +6,27 @@ DEFAULT_TTL_SECONDS = 600
 MAX_TTL_SECONDS = 1800
 class LeaseGateway:
     def __init__(self, service: LeaseService, approval: ApprovalClient):
-        # 作用：Lease 签发编排层（规格第 18/19 节）——先查可复用 ACTIVE Lease，未命中才走宿主 one-shot Approval 授权后签发
+        # 作用：Lease 签发编排层（规格第 18/19/20 节）——先查可复用 ACTIVE Lease，未命中先做阻断校验，最后才走宿主 one-shot Approval 授权后签发
         self._service = service
         self._approval = approval
     async def request(self, *, capsule_id: str, capsule_instance_id: str, session_id: str, provider: str, resource: str, action: str, ttl_seconds: int = DEFAULT_TTL_SECONDS, tool_name: str | None = None) -> CapabilityLease:
         # 作用：完整签发链路：同实例+会话+Provider+资源且已含该 action 的未过期 Lease 直接复用（不再弹 Approval）；
-        # 未命中或不含该 action 时经宿主 Approval 授权后签发新 Lease；TTL 非法（<=0 或超上限）一律拒绝（Fail Closed）
+        # 复用未命中时先做阻断校验——已撤销 Lease 立即 LEASE_REVOKED（规格第 20 节）、同资源的 ACTIVE Lease 被其他
+        # 会话/实例绑定时 LEASE_SESSION_MISMATCH / LEASE_CAPSULE_MISMATCH（规格第 24 节与第 37 节 Demo 第 8 项），
+        # 绝不静默重签绕过；仅当无阻断（首次/已过期/同调用者补新 action）才经宿主 Approval 授权后签发新 Lease；
+        # TTL 非法（<=0 或超上限）一律拒绝（Fail Closed）
         if ttl_seconds <= 0 or ttl_seconds > MAX_TTL_SECONDS:
             raise LeaseError("LEASE_REJECTED", f"invalid ttl_seconds: {ttl_seconds}")
         lease = await self._service.find_matching_lease(capsule_instance_id=capsule_instance_id, session_id=session_id, provider=provider, resource=resource)
         if lease is not None and action in lease.actions:
             return lease
+        latest = await self._service.find_latest_for_resource(provider=provider, resource=resource)
+        if latest is not None and latest.status == "REVOKED" and latest.session_id == session_id:
+            raise LeaseError("LEASE_REVOKED", f"lease {latest.id} has been revoked")
+        if latest is not None and latest.status == "ACTIVE" and time.time() < latest.expires_at:
+            if latest.session_id != session_id:
+                raise LeaseError("LEASE_SESSION_MISMATCH", "lease is bound to another session and cannot be reused here")
+            if latest.capsule_instance_id != capsule_instance_id:
+                raise LeaseError("LEASE_CAPSULE_MISMATCH", "lease is bound to another capsule instance")
         await self._approval.request_lease(capsule_id=capsule_id, provider=provider, resource=resource, action=action, ttl_seconds=ttl_seconds, tool_name=tool_name)
         return await self._service.issue(capsule_id=capsule_id, capsule_instance_id=capsule_instance_id, session_id=session_id, provider=provider, resource=resource, actions={action}, ttl_seconds=ttl_seconds)

--- a/runtime/dsh_capsule/lease/service.py
+++ b/runtime/dsh_capsule/lease/service.py
@@ -24,6 +24,9 @@ class LeaseService:
             await self._store.update_status(lease.id, "EXPIRED", "expired on lookup")
             return None
         return lease
+    async def find_latest_for_resource(self, *, provider: str, resource: str) -> CapabilityLease | None:
+        # 作用：阻断校验路径——查找该 Provider+资源的最新一条 Lease（不限实例与会话），供调用方检查撤销/跨会话等异常状态
+        return await self._store.find_for_resource(provider, resource)
     async def validate(self, *, capsule_instance_id: str, session_id: str, provider: str, resource: str, action: str) -> CapabilityLease:
         # 作用：规格第 17 节安全规则逐条校验，任意条件失败即抛对应错误码（Fail Closed，绝不"尽量执行"）
         lease = await self._store.find_for_resource(provider, resource)

--- a/tests/security/test_security_demo.py
+++ b/tests/security/test_security_demo.py
@@ -1,0 +1,127 @@
+import asyncio
+import socket
+import time
+from pathlib import Path
+import httpx
+import pytest
+from dsh_capsule.broker.credentials import CredentialResolver
+from dsh_capsule.broker.github import GitHubProvider
+from dsh_capsule.broker.providers import ProviderRegistry
+from dsh_capsule.broker.server import BrokerServer
+from dsh_capsule.capsule.manager import CapsuleManager
+from dsh_capsule.lease.approval import ApprovalClient
+from dsh_capsule.lease.gateway import LeaseGateway
+from dsh_capsule.lease.models import LeaseError
+from dsh_capsule.lease.service import LeaseService
+from dsh_capsule.storage.db import LeaseStore
+REPO_ROOT = Path(__file__).resolve().parents[2]
+IMAGES = {"dsh-capsule/hello:0.1.0": "capsules/hello/Dockerfile", "dsh-capsule/malicious-demo:0.1.0": "capsules/malicious-demo/Dockerfile", "dsh-capsule/github-reader:0.1.0": "capsules/github-reader/Dockerfile"}
+DEMO_TOKEN = "ghp_demo_secret_token"
+GITHUB_ISSUE = {"number": 10, "title": "Demo Issue", "state": "open", "user": {"login": "alice"}, "body": "hello from broker", "html_url": "https://github.com/foo/bar/issues/10"}
+def _docker_available() -> bool:
+    # 作用：探测 Docker Engine 是否可用；不可用则跳过安全 Demo
+    try:
+        import docker
+        docker.from_env().ping()
+        return True
+    except Exception:
+        return False
+requires_env = pytest.mark.skipif(not (_docker_available() and hasattr(socket, "AF_UNIX")), reason="requires Docker Engine + AF_UNIX (Linux/WSL2)")
+def _ensure_images() -> None:
+    # 作用：确保测试所需镜像存在，缺失则以仓库根为上下文构建
+    import docker
+    client = docker.from_env()
+    for tag, dockerfile in IMAGES.items():
+        try:
+            client.images.get(tag)
+        except docker.errors.ImageNotFound:
+            client.images.build(path=str(REPO_ROOT), tag=tag, dockerfile=dockerfile)
+class FakeHostConnection:
+    def __init__(self, decision: str = "allowed-once"):
+        # 作用：替代 TS 宿主的反向 RPC 通道——自动批准授权请求并返回 Demo Token，全程记录调用供断言
+        self.approvals: list[dict] = []
+        self.credential_calls: list[str] = []
+        self._decision = decision
+    async def call(self, method: str, params: dict | None = None, timeout: float = 30.0):
+        # 作用：处理宿主反向调用——approval 返回注入的决定；credential resolve 只按 ref 返回 Demo Token（不缓存）
+        if method == "host.approval.request_lease":
+            self.approvals.append(params or {})
+            return {"decision": self._decision}
+        if method == "host.credential.resolve":
+            self.credential_calls.append((params or {}).get("ref"))
+            return {"value": DEMO_TOKEN}
+        raise RuntimeError(f"unexpected host call: {method}")
+def _github_transport() -> httpx.MockTransport:
+    # 作用：GitHub API Mock——断言请求携带 Demo Token 且只打到预期 Issue 端点（无真实网络）
+    def handler(request: httpx.Request) -> httpx.Response:
+        assert request.headers["Authorization"] == f"Bearer {DEMO_TOKEN}"
+        assert request.url.path == "/repos/foo/bar/issues/10"
+        return httpx.Response(200, json=GITHUB_ISSUE)
+    return httpx.MockTransport(handler)
+@pytest.fixture(scope="module")
+def demo():
+    # 作用：模块级端到端环境——真实 Manager + BrokerServer + LeaseService(SQLite) + 假宿主通道 + Mock GitHub；
+    # 用例结束后回收容器与存储
+    class DemoEnv:
+        pass
+    _ensure_images()
+    env = DemoEnv()
+    env.host = FakeHostConnection()
+    env.store = LeaseStore(":memory:")
+    asyncio.run(env.store.connect())
+    env.gateway = LeaseGateway(LeaseService(env.store), ApprovalClient(env.host))
+    env.resolver = CredentialResolver(env.host)
+    env.providers = ProviderRegistry()
+    env.providers.register(GitHubProvider(transport=_github_transport()))
+    env.manager = CapsuleManager(
+        REPO_ROOT / "capsules",
+        broker_factory=lambda manifest, instance: BrokerServer(manifest, instance, env.gateway, env.resolver, env.providers),
+    )
+    yield env
+    asyncio.run(env.manager.shutdown())
+    asyncio.run(env.store.close())
+@requires_env
+def test_demo_5_issues_read_succeeds_via_broker(demo):
+    # 作用：Demo 第 5 项——首次 issues.read 触发宿主 Approval 授权，随后经 Lease→凭据→Provider 全链路成功返回 Issue；
+    # 二次调用复用 Lease 不再弹授权；Token 绝不出现在结果中（规格第 18/19/23 节）
+    result = asyncio.run(demo.manager.invoke("github_get_issue", {"repo": "foo/bar", "issue_number": 10}, session_id="S100"))
+    assert result["number"] == 10
+    assert result["title"] == "Demo Issue"
+    assert result["author"] == "alice"
+    assert DEMO_TOKEN not in str(result)
+    assert len(demo.host.approvals) == 1
+    assert demo.host.credential_calls.count("GITHUB_TOKEN") >= 1
+    result2 = asyncio.run(demo.manager.invoke("github_get_issue", {"repo": "foo/bar", "issue_number": 10}, session_id="S100"))
+    assert result2["number"] == 10
+    assert len(demo.host.approvals) == 1
+@requires_env
+def test_demo_6_unauthorized_action_denied(demo):
+    # 作用：Demo 第 6 项——manifest 未声明的 repo.delete 即 CAPABILITY_DENIED，且不触发任何 Approval（规格第 27/37 节）
+    approvals_before = len(demo.host.approvals)
+    with pytest.raises(RuntimeError, match="CAPABILITY_DENIED"):
+        asyncio.run(demo.manager.invoke("try_unauthorized_broker_action", {}, session_id="S100"))
+    assert len(demo.host.approvals) == approvals_before
+@requires_env
+def test_demo_7_revoked_lease_denied(demo):
+    # 作用：Demo 第 7 项——撤销 Lease 后同会话的 issues.read 立即 LEASE_REVOKED，不静默重签（规格第 20 节）
+    asyncio.run(demo.manager.invoke("github_get_issue", {"repo": "foo/bar", "issue_number": 10}, session_id="S300"))
+    leases = [l for l in asyncio.run(demo.store.list_all()) if l.session_id == "S300"]
+    assert len(leases) == 1
+    asyncio.run(LeaseService(demo.store).revoke(leases[0].id, "demo revoke"))
+    with pytest.raises(RuntimeError, match="LEASE_REVOKED"):
+        asyncio.run(demo.manager.invoke("github_get_issue", {"repo": "foo/bar", "issue_number": 10}, session_id="S300"))
+@requires_env
+def test_demo_8_cross_session_reuse_denied(demo):
+    # 作用：Demo 第 8 项——Session B 尝试复用 Session A 的 Lease 即 LEASE_SESSION_MISMATCH，且不为 B 静默重签（规格第 24/37 节）
+    asyncio.run(demo.manager.invoke("github_get_issue", {"repo": "foo/bar", "issue_number": 10}, session_id="S400"))
+    approvals_before = len(demo.host.approvals)
+    with pytest.raises(RuntimeError, match="LEASE_SESSION_MISMATCH"):
+        asyncio.run(demo.manager.invoke("github_get_issue", {"repo": "foo/bar", "issue_number": 10}, session_id="S500"))
+    assert len(demo.host.approvals) == approvals_before
+@requires_env
+def test_demo_9_capsule_crash_runtime_survives(demo):
+    # 作用：Demo 第 9 项——malicious-demo 容器自杀后 Runtime 主进程仍正常，实例自动重建恢复可用（规格第 37 节）
+    with pytest.raises(RuntimeError):
+        asyncio.run(demo.manager.invoke("attack_crash", {}, session_id="S100"))
+    result = asyncio.run(demo.manager.invoke("probe_env", {}, session_id="S100"))
+    assert "env" in result

--- a/tests/unit/test_lease_gateway.py
+++ b/tests/unit/test_lease_gateway.py
@@ -1,4 +1,5 @@
 import asyncio
+import time
 import pytest
 from dsh_capsule.lease.approval import ApprovalClient
 from dsh_capsule.lease.gateway import LeaseGateway
@@ -59,12 +60,37 @@ def test_new_action_requires_new_approval(gateway_parts):
     assert second.id != first.id
     assert "issues.write" in second.actions
 def test_cross_session_no_reuse(gateway_parts):
-    # 作用：Session B 请求同资源不走 Session A 的复用路径，必须重新授权（不能跨 Session 复用）
+    # 作用：Session B 尝试复用 Session A 的 Lease 即 LEASE_SESSION_MISMATCH，且不会为 B 静默重签（规格第 24 节与第 37 节 Demo 第 8 项）
     gateway, conn = _make_gateway(gateway_parts, approval_result={"decision": "allowed-once"})
     asyncio.run(gateway.request(**BASE))
-    lease_b = asyncio.run(gateway.request(**{**BASE, "session_id": "S200"}))
+    with pytest.raises(LeaseError, match="LEASE_SESSION_MISMATCH"):
+        asyncio.run(gateway.request(**{**BASE, "session_id": "S200"}))
+    assert len(conn.calls) == 1
+def test_cross_instance_no_reuse(gateway_parts):
+    # 作用：其他实例尝试复用同资源 ACTIVE Lease 即 LEASE_CAPSULE_MISMATCH（Lease 绑定实例，Fail Closed）
+    gateway, conn = _make_gateway(gateway_parts, approval_result={"decision": "allowed-once"})
+    asyncio.run(gateway.request(**BASE))
+    with pytest.raises(LeaseError, match="LEASE_CAPSULE_MISMATCH"):
+        asyncio.run(gateway.request(**{**BASE, "capsule_instance_id": "inst-2"}))
+    assert len(conn.calls) == 1
+def test_revoked_lease_blocks_next_request(gateway_parts):
+    # 作用：撤销后的下一次请求立即 LEASE_REVOKED，且不会自动重签（规格第 20 节"绝对不能等到重启才生效"）
+    gateway, conn = _make_gateway(gateway_parts, approval_result={"decision": "allowed-once"})
+    lease = asyncio.run(gateway.request(**BASE))
+    asyncio.run(LeaseService(gateway_parts).revoke(lease.id))
+    with pytest.raises(LeaseError, match="LEASE_REVOKED"):
+        asyncio.run(gateway.request(**BASE))
+    assert len(conn.calls) == 1
+def test_expired_lease_reauthorizes(gateway_parts):
+    # 作用：Lease 过期后不复用（复用路径按 expires_at 拒绝）也不阻断，走宿主重新授权签发新 Lease（规格第 21 节）
+    gateway, conn = _make_gateway(gateway_parts, approval_result={"decision": "allowed-once"})
+    first = asyncio.run(gateway.request(**BASE, ttl_seconds=1))
+    first.expires_at = time.time() - 1
+    asyncio.run(gateway_parts.update_status(first.id, "EXPIRED", "forced expiry for test"))
+    second = asyncio.run(gateway.request(**BASE))
     assert len(conn.calls) == 2
-    assert lease_b.session_id == "S200"
+    assert second.id != first.id
+    assert second.status == "ACTIVE"
 def test_invalid_ttl_rejected_without_approval(gateway_parts):
     # 作用：TTL 非法（<=0 或超上限 1800）在发起授权前即抛 LEASE_REJECTED（Fail Closed）
     gateway, conn = _make_gateway(gateway_parts, approval_result={"decision": "allowed-once"})


### PR DESCRIPTION
- LeaseGateway 增加阻断校验：同会话已撤销 Lease 立即 LEASE_REVOKED（第 20 节）、 跨会话/跨实例复用即 LEASE_SESSION_MISMATCH / LEASE_CAPSULE_MISMATCH（第 24 节）， 绝不静默重签绕过；过期与异会话撤销走重新授权
- LeaseService 新增 find_latest_for_resource（按资源取最新 Lease 供阻断判断）
- 新增 tests/security/test_security_demo.py：真实 Docker + Broker + Lease + Mock GitHub 链路演示第 37 节 9 项（issues.read 成功/越权拒绝/撤销失效/跨会话拒绝/崩溃隔离）
- gateway 单测补 4 个阻断用例；全量 85 passed