### PR TITLE
docs(readme): fix Docker build context and document capsulectl CLI usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -388,9 +388,9 @@ cd ..
 ### 3. 构建示例 Capsule
 
 ```bash
-docker build -t dsh-capsule/hello:0.1.0 capsules/hello
-docker build -t dsh-capsule/github-reader:0.1.0 capsules/github-reader
-docker build -t dsh-capsule/malicious-demo:0.1.0 capsules/malicious-demo
+docker build -f capsules/hello/Dockerfile -t dsh-capsule/hello:0.1.0 .
+docker build -f capsules/github-reader/Dockerfile -t dsh-capsule/github-reader:0.1.0 .
+docker build -f capsules/malicious-demo/Dockerfile -t dsh-capsule/malicious-demo:0.1.0 .
 ```
 
 ### 4. 运行 Python 测试
@@ -531,7 +531,9 @@ Capsule 永远不会拿到 `GITHUB_TOKEN`。只有当 Lease 与 Manifest Policy 
 
 ## 🛠️ CLI
 
-仓库包含 `capsulectl.py`，用于 Lease 运维与撤销管理。
+仓库包含 `cli/capsulectl.py`，用于 Lease 运维与撤销管理。
+
+全局参数 `--db` 指定 Lease SQLite 数据库路径（默认 `leases.db`），需写在子命令之前。
 
 支持的核心操作包括：
 
@@ -542,7 +544,15 @@ revoke-session <session-id>
 revoke-capsule <capsule-id>
 ```
 
-因此“权限可撤销”不是架构图上的理论属性，而是一个可以被实际执行的 Runtime Control。
+在仓库根目录、`dsh_capsule` 可导入的环境下执行：
+
+```bash
+uv run --project runtime python cli/capsulectl.py --db leases.db leases
+uv run --project runtime python cli/capsulectl.py --db leases.db revoke <lease-id>
+uv run --project runtime python cli/capsulectl.py --db leases.db revoke-session <session-id>
+uv run --project runtime python cli/capsulectl.py --db leases.db revoke-capsule <capsule-id>
+```
+
 
 ---
 


### PR DESCRIPTION
Two documentation issues found while following the README end to end. Docs only, no code changes.

## 1. The documented `docker build` commands cannot work

`README.md` -> "3. 构建示例 Capsule" builds the capsules with the capsule directory as the build context:

```
docker build -t dsh-capsule/hello:0.1.0 capsules/hello
```

But every Dockerfile copies from the repository root:

`capsules/hello/Dockerfile`
```
COPY sdk/python /sdk
COPY capsules/hello/app.py /app/app.py
```

Since both source paths are resolved against the build context, a `capsules/hello` context fails at the very first COPY:

```
COPY failed: file not found in build context ...: stat sdk/python: file does not exist
```

The context has to be the repository root, with the Dockerfile passed via `-f`. Fixed for all three capsules:

```
docker build -f capsules/hello/Dockerfile -t dsh-capsule/hello:0.1.0 .
```

## 2. CLI section: wrong path, undocumented flag, no runnable example

- `capsulectl.py` lives in `cli/`, not at the repository root.
- The global `--db` flag is not documented. It is registered on the top-level argparse parser, so it must be passed **before** the subcommand -- `capsulectl.py --db leases.db leases`, not `capsulectl.py leases --db leases`. Passing it after the subcommand is rejected.
- Added runnable examples for all four subcommands (`leases`, `revoke`, `revoke-session`, `revoke-capsule`).

## Verification

Markdown fences are balanced and the only changed file is `README.md`.